### PR TITLE
add style guide graph colors

### DIFF
--- a/stylesheets/common.styl
+++ b/stylesheets/common.styl
@@ -16,6 +16,14 @@ mp-red = #e4567b
 mp-yellow = #ffd209
 seafoam = #47b6ac
 
+color-aquamarine = #106eca
+color-navy = #23588c
+color-orange = #f2af34
+color-seafoam = #47b6ac
+color-turquoise = #24d2ef
+color-ultramarine = #106eca
+color-yellow = #ffd209
+
 /* Text styles */
 
 font-list-item()

--- a/stylesheets/common.styl
+++ b/stylesheets/common.styl
@@ -11,18 +11,19 @@ grey-300 = #c1ccd6
 grey-500 = #9cacbb
 grey-700 = #6e859d
 grey-900 = #4c6072
-mp-purple = #9271e2
-mp-red = #e4567b
-mp-yellow = #ffd209
+
+// FIXME deprecated, use mp-seafoam
 seafoam = #47b6ac
 
-color-aquamarine = #106eca
-color-navy = #23588c
-color-orange = #f2af34
-color-seafoam = #47b6ac
-color-turquoise = #24d2ef
-color-ultramarine = #106eca
-color-yellow = #ffd209
+mp-aquamarine = #106eca
+mp-navy = #23588c
+mp-orange = #f2af34
+mp-purple = #9271e2
+mp-red = #e4567b
+mp-seafoam = #47b6ac
+mp-turquoise = #24d2ef
+mp-ultramarine = #106eca
+mp-yellow = #ffd209
 
 /* Text styles */
 


### PR DESCRIPTION
NB `color-seafoam` is the same as `seafoam`; i'd love to see the old one get removed once autotrack has a chance to update. Using the `color-` prefix on these to avoid collisions with global css colors.