### PR TITLE
improve the modal API to work nicely imperatively or declaratively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - "6.2"
 language: node_js
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - "export DISPLAY=:30"
+  - "sh -e /etc/init.d/xvfb :30 start"
 script: "webpack --context test --config test/webpack.config.js && wct --plugin local"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ language: node_js
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+script: "webpack --context test --config test/webpack.config.js && wct --plugin local"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "6.2"
 language: node_js
 before_install:
-  - "export DISPLAY=:30"
+  - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,4 @@ node_js:
   - "4.2"
   - "6.2"
 language: node_js
-before_install:
-  - "export DISPLAY=:30"
-  - "sh -e /etc/init.d/xvfb :30 start"
-script: "webpack --context test --config test/webpack.config.js && wct --plugin local"
+script: "webpack --context test --config test/webpack.config.js && wct --plugin sauce"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ node_js:
   - "4.2"
   - "6.2"
 language: node_js
+before_install:
+  - "export DISPLAY=:30"
+  - "sh -e /etc/init.d/xvfb start"

--- a/examples/index.html
+++ b/examples/index.html
@@ -31,23 +31,23 @@
       Mouse over me!
       <mp-tooltip>This is my tooltip</mp-tooltip>
     </mp-button>
-    <mp-modal id="modal" closeable closed>
+    <mp-modal id="modal" closeable>
       <div class="mp-modal-title" slot-body>Easily track events</div>
       <div class="mp-modal-subtitle" slot-body>Click on any element on your page (ex. the buy button) to create an event and access all historical data for that event.</div>
       <mp-button class="mp-button-modal mp-button-primary" onclick="closeModal();" slot-button arrow-next>Create your first event</mp-button>
     </mp-modal>
-    <mp-modal id="popup" width="500px" modal-type="popup" closeable closed>
+    <mp-modal id="popup" width="500px" modal-type="popup" closeable>
       <div class="mp-modal-title" slot-body>Easily track events</div>
       <div class="mp-modal-subtitle" slot-body>Click on any element on your page (ex. the buy button) to create an event and access all historical data for that event.</div>
       <mp-button class="mp-button-modal mp-button-primary" onclick="closePopup();" slot-button>Create your first event</mp-button>
     </mp-modal>
-    <mp-modal id="alert-modal" modal-type="popup" closeable alert closed>
+    <mp-modal id="alert-modal" modal-type="popup" closeable alert>
       <div slot-body>
         <div class="mp-modal-alert-title">Your event failed to save</div>
         <div class="mp-modal-alert-subtitle">If your issue persists please contact our support team at support@mixpanel.com to get help quickly</div>
       </div>
     </mp-modal>
-    <mp-modal id="purple-modal" width="500px" closeable closed>
+    <mp-modal id="purple-modal" width="500px" closeable>
       <div class="mp-modal-title" slot-body>I'm a modal with a purple button</div>
       <div class="mp-modal-subtitle" slot-body>We use this for upsell dialogs</div>
       <mp-button class="mp-button-modal mp-button-purple" onclick="closePurpleModal();" slot-button arrow-next>Upgrade</mp-button>
@@ -68,35 +68,11 @@
 
     <script type="application/javascript">
       var modal = document.getElementById('modal');
-      modal.addEventListener('change', function(e) {
-        if (e.detail.state === 'closed') {
-            modal.setAttribute('closed', true);
-        }
-      });
-
       var popup = document.getElementById('popup');
-      popup.addEventListener('change', function(e) {
-          if (e.detail.state === 'closed') {
-              popup.setAttribute('closed', true);
-          }
-      });
-
       var alertModal = document.getElementById('alert-modal');
-      alertModal.addEventListener('change', function(e) {
-          if (e.detail.state === 'closed') {
-              alertModal.setAttribute('closed', true);
-          }
-      });
-
       var purpleModal = document.getElementById('purple-modal');
-      purpleModal.addEventListener('change', function(e) {
-          if (e.detail.state === 'closed') {
-              purpleModal.setAttribute('closed', true);
-          }
-      });
 
       var openPurpleModal = function() {
-        purpleModal.removeAttribute('closed');
         purpleModal.open();
       };
 
@@ -105,18 +81,16 @@
       };
 
       var openModal = function() {
-        modal.removeAttribute('closed');
         modal.open();
       };
 
       var closeModal = function() {
         modal.close().then(function() {
-          console.log('modal closed!');
+          console.log('modal!');
         });
       }
 
       var openPopup = function() {
-        popup.removeAttribute('closed');
         popup.open();
       };
 
@@ -125,7 +99,6 @@
       };
 
       var openAlertModal = function() {
-        alertModal.removeAttribute('closed');
         alertModal.open();
       };
 

--- a/examples/panel/index.html
+++ b/examples/panel/index.html
@@ -5,7 +5,7 @@
     <script src="../../node_modules/babel-polyfill/dist/polyfill.js"></script>
     <script src="../../node_modules/webcomponents.js/webcomponents.js"></script>
     <script src="../build/mixpanel-common.js"></script>
-    <script src="../build/virtual-jade-example.js"></script>
+    <script src="../build/panel-example.js"></script>
     <style type="text/css">
       body {
         margin: 0;

--- a/examples/panel/index.jade
+++ b/examples/panel/index.jade
@@ -1,13 +1,8 @@
 .container
-  if buttonSet === 1
-    .inner.one
-      mp-button.mp-button-primary(onclick=$helpers.nextState) Oh sick
-      mp-button.mp-button-secondary(onclick=$helpers.nextState) Oh sick
-  else if buttonSet === 2
-    .inner.two
-      mp-button.mp-button-secondary(onclick=$helpers.prevState) Oh sick 2
-      mp-button.mp-button-primary(onclick=$helpers.prevState) Oh sick 2
-    .inner.one
-      mp-button.mp-button-primary(onclick=$helpers.nextState) Oh sick
-      mp-button.mp-button-secondary(onclick=$helpers.nextState) Oh sick
-
+  mp-button.mp-button-primary(onclick=$helpers.openModal) Open a modal
+  mp-modal(attributes={closeable: true, closed: !modalOpen} onchange=$helpers.handleModalChange)
+    .mp-modal-title(attributes={'slot-body': true}) Look I'm a declarative modal
+    .mp-modal-subtitle(attributes={'slot-body': true})
+      | I open or close based on the value of the "closed" attribute
+    mp-button.mp-button-modal.mp-button-primary(onclick=$helpers.closeModal attributes={'slot-button': true})
+      | Done

--- a/examples/panel/index.js
+++ b/examples/panel/index.js
@@ -11,16 +11,27 @@ document.registerElement('demo-app', class extends Component {
       css,
 
       defaultState: {
-        buttonSet: 1,
+        modalOpen: true,
       },
 
       helpers: {
-        nextState: () => {
-          this.update({buttonSet: 2});
+        openModal: () => {
+          this.update({modalOpen: true});
         },
 
-        prevState: () => {
-          this.update({buttonSet: 1});
+        closeModal: () => {
+          this.update({modalOpen: false});
+        },
+
+        handleModalChange: (e) => {
+          switch(e.detail.state) {
+            case 'closed':
+              this.update({modalOpen: false});
+              break;
+            case 'open':
+              this.update({modalOpen: true});
+              break;
+          }
         },
       },
 
@@ -29,5 +40,4 @@ document.registerElement('demo-app', class extends Component {
       useShadowDom: true,
     };
   }
-
 });

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -2,12 +2,12 @@ var path = require('path');
 
 var webpackConfig = {
   entry: {
-    'mixpanel-common': './lib/index.js',
-    'panel-example': './examples/panel/index.js'
+    'mixpanel-common': '../lib/index.js',
+    'panel-example': './panel/index.js',
   },
   output: {
     filename: '[name].js',
-    path: path.join(__dirname, '/examples/build/')
+    path: path.join(__dirname, '/build/')
   },
   module: {
     loaders: [

--- a/lib/components/buttons/button.js
+++ b/lib/components/buttons/button.js
@@ -1,5 +1,7 @@
 import { Component } from 'panel';
 
+import '../registration.js';
+
 import template from './button.jade';
 
 import css from './button.styl';

--- a/lib/components/buttons/button.styl
+++ b/lib/components/buttons/button.styl
@@ -9,6 +9,10 @@ background-primary-on-blue-hover = blue-100 linear-gradient(#8cc7ff, #7bbfff)
 background-primary-red = mp-red linear-gradient(#EA8499, #E4687D)
 background-primary-red-hover = mp-red linear-gradient(to bottom, #ED92A4, #EA8499)
 
+active = '&:active,&[active]'
+disabled = '&:disabled,&[disabled]'
+not-disabled = ':not([disabled]):not(:disabled)'
+
 +prefix-classes('mp-button-')
   .container
     align-items center
@@ -113,7 +117,7 @@ background-primary-red-hover = mp-red linear-gradient(to bottom, #ED92A4, #EA849
       border 1px solid #7858b8
 
       &:hover{not-disabled}
-        background #b299ea
+        background #A081EA
         border 1px solid #9270e2
 
     /* END COLOR THEMES */

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -1,4 +1,3 @@
-import './registration.js';
 import './buttons/button.js';
 import './modals/modal.js';
 import './tooltips/tooltip.js';

--- a/lib/components/modals/modal.jade
+++ b/lib/components/modals/modal.jade
@@ -1,12 +1,12 @@
 .mp-modal-stage(class={
   'mp-modal-alert': $component.isAttributeEnabled('alert'),
   'mp-modal-absolute': $component.isAttributeEnabled('not-fullscreen'),
-  'mp-modal-closed': state === 'closed',
+  'mp-modal-closed': visiblity === 'closed',
 })
   if $helpers.getType() === 'modal'
-    .mp-modal-backdrop(onclick=$helpers.backdropClicked class='mp-modal-#{state}')
+    .mp-modal-backdrop(onclick=$helpers.backdropClicked class='mp-modal-#{visibility}')
   .mp-modal-wrapper
-    .mp-modal-main(style=$helpers.getModalStyles() class='mp-modal-#{state}')
+    .mp-modal-main(style=$helpers.getModalStyles() class='mp-modal-#{visibility}')
       if $component.isAttributeEnabled('closeable')
         .mp-modal-close-btn(onclick=$helpers.closeClicked)
           .mp-modal-close-icon

--- a/lib/components/modals/modal.jade
+++ b/lib/components/modals/modal.jade
@@ -1,12 +1,12 @@
 .mp-modal-stage(class={
   'mp-modal-alert': $component.isAttributeEnabled('alert'),
   'mp-modal-absolute': $component.isAttributeEnabled('not-fullscreen'),
-  'mp-modal-closed': closed,
+  'mp-modal-closed': state === 'closed',
 })
   if $helpers.getType() === 'modal'
-    .mp-modal-backdrop(onclick=$helpers.backdropClicked class={'mp-modal-closing': closing})
+    .mp-modal-backdrop(onclick=$helpers.backdropClicked class='mp-modal-#{state}')
   .mp-modal-wrapper
-    .mp-modal-main(style=$helpers.getModalStyles() class={'mp-modal-closing': closing})
+    .mp-modal-main(style=$helpers.getModalStyles() class='mp-modal-#{state}')
       if $component.isAttributeEnabled('closeable')
         .mp-modal-close-btn(onclick=$helpers.closeClicked)
           .mp-modal-close-icon

--- a/lib/components/modals/modal.jade
+++ b/lib/components/modals/modal.jade
@@ -1,12 +1,12 @@
 .mp-modal-stage(class={
   'mp-modal-alert': $component.isAttributeEnabled('alert'),
   'mp-modal-absolute': $component.isAttributeEnabled('not-fullscreen'),
-  'mp-modal-closed': $component.isAttributeEnabled('closed'),
+  'mp-modal-closed': closed,
 })
   if $helpers.getType() === 'modal'
-    .mp-modal-backdrop(onclick=$helpers.backdropClicked)
+    .mp-modal-backdrop(onclick=$helpers.backdropClicked class={'mp-modal-closing': closing})
   .mp-modal-wrapper
-    .mp-modal-main(style=$helpers.getModalStyles())
+    .mp-modal-main(style=$helpers.getModalStyles() class={'mp-modal-closing': closing})
       if $component.isAttributeEnabled('closeable')
         .mp-modal-close-btn(onclick=$helpers.closeClicked)
           .mp-modal-close-icon

--- a/lib/components/modals/modal.jade
+++ b/lib/components/modals/modal.jade
@@ -1,7 +1,7 @@
 .mp-modal-stage(class={
   'mp-modal-alert': $component.isAttributeEnabled('alert'),
   'mp-modal-absolute': $component.isAttributeEnabled('not-fullscreen'),
-  'mp-modal-closed': visiblity === 'closed',
+  'mp-modal-closed': visibility === 'closed',
 })
   if $helpers.getType() === 'modal'
     .mp-modal-backdrop(onclick=$helpers.backdropClicked class='mp-modal-#{visibility}')

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -59,25 +59,13 @@ class MPModal extends Component {
   }
 
   close() {
-    if (this.state.closed) {
-      return Promise.resolve();
-    } else if (this.state.closing) {
-      return this._closingPromise;
-    } else {
-      this._closingPromise = new Promise(resolve => {
-        this.addEventListener('change', e => {
-          if (e.detail.state === 'closed') {
-            resolve();
-          }
-        });
-        this.update({opening: false, closing: true});
-      });
-      return this._closingPromise;
+    if (!(this.state.closing || this.state.closed)) {
+      this.update({opening: false, closing: true});
     }
   }
 
   open() {
-    if (this.state.closed) {
+    if (this.state.closed && !this.state.opening) {
       this.update({opening: true, closed: false});
     }
   }

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -51,14 +51,14 @@ class MPModal extends Component {
       case VISIBILITY_CLOSING:
         break;
       case VISIBILITY_OPENING:
-        this.update({state: VISIBILITY_CLOSED});
+        this.update({visibility: VISIBILITY_CLOSED});
         break;
       case VISIBILITY_OPEN:
         this._pendingAnimations = ['fadeModalOut'];
         if (this.config.helpers.getType() === 'modal') {
           this._pendingAnimations.push('fadeOverlayOut');
         }
-        this.update({state: VISIBILITY_CLOSING});
+        this.update({visibility: VISIBILITY_CLOSING});
         break;
     }
   }
@@ -69,14 +69,14 @@ class MPModal extends Component {
       case VISIBILITY_OPENING:
         break;
       case VISIBILITY_CLOSING:
-        this.update({state: VISIBILITY_OPEN});
+        this.update({visibility: VISIBILITY_OPEN});
         break;
       case VISIBILITY_CLOSED:
         this._pendingAnimations = ['fadeModalIn'];
         if (this.config.helpers.getType() === 'modal') {
           this._pendingAnimations.push('fadeOverlayIn');
         }
-        this.update({state: VISIBILITY_OPENING});
+        this.update({visibility: VISIBILITY_OPENING});
         break;
     }
   }
@@ -103,11 +103,11 @@ class MPModal extends Component {
       }
       switch(this.state.visibility) {
         case VISIBILITY_OPENING:
-          this.update({state: VISIBILITY_OPEN});
+          this.update({visibility: VISIBILITY_OPEN});
           this.dispatchEvent(new CustomEvent('change', {detail: {state: VISIBILITY_OPEN}}));
           break;
         case VISIBILITY_CLOSING:
-          this.update({state: VISIBILITY_CLOSED});
+          this.update({visibility: VISIBILITY_CLOSED});
           this.dispatchEvent(new CustomEvent('change', {detail: {state: VISIBILITY_CLOSED}}));
           break;
       }

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -126,12 +126,12 @@ class MPModal extends Component {
     offAnimationEnd(this.el, this._onAnimationEnd);
   }
 
-  attributeChangedCallback(name, oldVal, newVal) {
+  attributeChangedCallback(name) {
     super.attributeChangedCallback(...arguments);
     if (this.initialized && name === 'closed') {
-      if (newVal === 'true') {
+      if (this.isAttributeEnabled('closed')) {
         this.close();
-      } else if (!newVal || newVal === 'false') {
+      } else {
         this.open();
       }
     }

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -4,12 +4,37 @@ import template from './modal.jade';
 
 import css from './modal.styl';
 
+const ANIMATION_START_EVENTS = ['webkitAnimationStart', 'animationstart', 'oAnimationStart', 'MSAnimationStart'];
+const ANIMATION_END_EVENTS = ['webkitAnimationEnd', 'animationend', 'oAnimationEnd', 'MSAnimationEnd'];
+
+const onAnimationStart = (el, callback) => {
+  ANIMATION_START_EVENTS.forEach(e => el.addEventListener(e, callback));
+};
+
+const offAnimationStart = (el, callback) => {
+  ANIMATION_START_EVENTS.forEach(e => el.removeEventListener(e, callback));
+};
+
+const onAnimationEnd = (el, callback) => {
+  ANIMATION_END_EVENTS.forEach(e => el.addEventListener(e, callback));
+};
+
+const offAnimationEnd = (el, callback) => {
+  ANIMATION_END_EVENTS.forEach(e => el.removeEventListener(e, callback));
+};
+
+
 class MPModal extends Component {
   get config() {
     return {
       css,
       template,
       useShadowDom: true,
+      defaultState: {
+        closed: true,
+        closing: false,
+        opening: false,
+      },
       helpers: {
         backdropClicked: () => {
           if (this.isAttributeEnabled('closeable')) {
@@ -34,35 +59,84 @@ class MPModal extends Component {
   }
 
   close() {
-    return new Promise((resolve) => {
-      Array.from(this.el.querySelectorAll('.mp-modal-backdrop, .mp-modal-main'))
-        .forEach(el => el.classList.add('mp-modal-closing'));
-      setTimeout(() => {
-        this.dispatchEvent(new CustomEvent('change', {detail: {state: 'closed'}}));
-        resolve();
-      }, 700);
-    });
+    if (this.state.closed) {
+      return Promise.resolve();
+    } else if (this.state.closing) {
+      return this._closingPromise;
+    } else {
+      this._closingPromise = new Promise(resolve => {
+        this.addEventListener('change', e => {
+          if (e.detail.state === 'closed') {
+            resolve();
+          }
+        });
+        this.update({opening: false, closing: true});
+      });
+      return this._closingPromise;
+    }
   }
 
   open() {
-    Array.from(this.el.querySelectorAll('.mp-modal-backdrop, .mp-modal-main'))
-      .forEach(el => el.classList.remove('mp-modal-closing'));
+    if (this.state.closed) {
+      this.update({opening: true, closed: false});
+    }
   }
 
   attachedCallback() {
     super.attachedCallback(...arguments);
+    this._attached = true;
+
+    // listen for escape keypress
     this.maybeCloseOnEscape = (e) => {
       if (this.isAttributeEnabled('closeable') && e.keyCode === 27) {
         this.close();
       }
     };
     document.body.addEventListener('keydown', this.maybeCloseOnEscape);
+
+    // use animation events to determine when the modal is done transitioning
+    // between open or closed states
+    this._animationCount = 0;
+    this._onAnimationStart = () => this._animationCount++;
+    this._onAnimationEnd = () => {
+      this._animationCount--;
+      if (this._animationCount === 0) {
+        if (this.state.opening) {
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'open'}}));
+          this.update({opening: false});
+        } else if (this.state.closing) {
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'closed'}}));
+          this.update({closing: false, closed: true});
+        }
+      }
+    };
+    onAnimationStart(this.el, this._onAnimationStart);
+    onAnimationEnd(this.el, this._onAnimationEnd);
+
+    // open the modal if "closed" is explicitly set to false
+    if (this.getAttribute('closed') === 'false') {
+      this.open();
+    }
   }
 
   detachedCallback() {
     super.detachedCallback(...arguments);
     document.body.removeEventListener('keydown', this.maybeCloseOnEscape);
+    offAnimationStart(this.el, this._onAnimationStart);
+    offAnimationEnd(this.el, this._onAnimationEnd);
   }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    super.attributeChangedCallback(...arguments);
+    if (this._attached && name === 'closed') {
+      if (newVal === 'true') {
+        this.close();
+      } else if (!newVal || newVal === 'false') {
+        this.open();
+      }
+    }
+  }
+
 }
 
 if (window['mp-common-registered-components']['mp-modal'] !== true) {

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -1,5 +1,7 @@
 import { Component } from 'panel';
 
+import '../registration.js';
+
 import template from './modal.jade';
 
 import css from './modal.styl';
@@ -60,12 +62,14 @@ class MPModal extends Component {
 
   close() {
     if (!(this.state.closing || this.state.closed)) {
+      this._animationCount = 0;
       this.update({opening: false, closing: true});
     }
   }
 
   open() {
     if (this.state.closed && !this.state.opening) {
+      this._animationCount = 0;
       this.update({opening: true, closing: false, closed: false});
     }
   }
@@ -90,11 +94,11 @@ class MPModal extends Component {
       this._animationCount--;
       if (this._animationCount === 0) {
         if (this.state.opening) {
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'open'}}));
           this.update({opening: false});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'open'}}));
         } else if (this.state.closing) {
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'closed'}}));
           this.update({closing: false, closed: true});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'closed'}}));
         }
       }
     };

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -66,7 +66,7 @@ class MPModal extends Component {
 
   open() {
     if (this.state.closed && !this.state.opening) {
-      this.update({opening: true, closed: false});
+      this.update({opening: true, closing: false, closed: false});
     }
   }
 

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -8,10 +8,10 @@ import css from './modal.styl';
 
 import { onAnimationEnd, offAnimationEnd } from '../utils';
 
-const STATE_OPEN = 'open';
-const STATE_OPENING = 'opening';
-const STATE_CLOSED = 'closed';
-const STATE_CLOSING = 'closing';
+const VISIBILITY_OPEN = 'open';
+const VISIBILITY_OPENING = 'opening';
+const VISIBILITY_CLOSED = 'closed';
+const VISIBILITY_CLOSING = 'closing';
 
 class MPModal extends Component {
   get config() {
@@ -20,7 +20,7 @@ class MPModal extends Component {
       template,
       useShadowDom: true,
       defaultState: {
-        state: STATE_CLOSED,
+        visibility: VISIBILITY_CLOSED,
       },
       helpers: {
         backdropClicked: () => {
@@ -46,37 +46,37 @@ class MPModal extends Component {
   }
 
   close() {
-    switch(this.state.state) {
-      case STATE_CLOSED:
-      case STATE_CLOSING:
+    switch(this.state.visibility) {
+      case VISIBILITY_CLOSED:
+      case VISIBILITY_CLOSING:
         break;
-      case STATE_OPENING:
-        this.update({state: STATE_CLOSED});
+      case VISIBILITY_OPENING:
+        this.update({state: VISIBILITY_CLOSED});
         break;
-      case STATE_OPEN:
+      case VISIBILITY_OPEN:
         this._pendingAnimations = ['fadeModalOut'];
         if (this.config.helpers.getType() === 'modal') {
           this._pendingAnimations.push('fadeOverlayOut');
         }
-        this.update({state: STATE_CLOSING});
+        this.update({state: VISIBILITY_CLOSING});
         break;
     }
   }
 
   open() {
-    switch(this.state.state) {
-      case STATE_OPEN:
-      case STATE_OPENING:
+    switch(this.state.visibility) {
+      case VISIBILITY_OPEN:
+      case VISIBILITY_OPENING:
         break;
-      case STATE_CLOSING:
-        this.update({state: STATE_OPEN});
+      case VISIBILITY_CLOSING:
+        this.update({state: VISIBILITY_OPEN});
         break;
-      case STATE_CLOSED:
+      case VISIBILITY_CLOSED:
         this._pendingAnimations = ['fadeModalIn'];
         if (this.config.helpers.getType() === 'modal') {
           this._pendingAnimations.push('fadeOverlayIn');
         }
-        this.update({state: STATE_OPENING});
+        this.update({state: VISIBILITY_OPENING});
         break;
     }
   }
@@ -101,14 +101,14 @@ class MPModal extends Component {
       if (this._pendingAnimations.length > 0) {
         return;
       }
-      switch(this.state.state) {
-        case STATE_OPENING:
-          this.update({state: STATE_OPEN});
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: STATE_OPEN}}));
+      switch(this.state.visibility) {
+        case VISIBILITY_OPENING:
+          this.update({state: VISIBILITY_OPEN});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: VISIBILITY_OPEN}}));
           break;
-        case STATE_CLOSING:
-          this.update({state: STATE_CLOSED});
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: STATE_CLOSED}}));
+        case VISIBILITY_CLOSING:
+          this.update({state: VISIBILITY_CLOSED});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: VISIBILITY_CLOSED}}));
           break;
       }
     };

--- a/lib/components/modals/modal.js
+++ b/lib/components/modals/modal.js
@@ -6,25 +6,12 @@ import template from './modal.jade';
 
 import css from './modal.styl';
 
-const ANIMATION_START_EVENTS = ['webkitAnimationStart', 'animationstart', 'oAnimationStart', 'MSAnimationStart'];
-const ANIMATION_END_EVENTS = ['webkitAnimationEnd', 'animationend', 'oAnimationEnd', 'MSAnimationEnd'];
+import { onAnimationEnd, offAnimationEnd } from '../utils';
 
-const onAnimationStart = (el, callback) => {
-  ANIMATION_START_EVENTS.forEach(e => el.addEventListener(e, callback));
-};
-
-const offAnimationStart = (el, callback) => {
-  ANIMATION_START_EVENTS.forEach(e => el.removeEventListener(e, callback));
-};
-
-const onAnimationEnd = (el, callback) => {
-  ANIMATION_END_EVENTS.forEach(e => el.addEventListener(e, callback));
-};
-
-const offAnimationEnd = (el, callback) => {
-  ANIMATION_END_EVENTS.forEach(e => el.removeEventListener(e, callback));
-};
-
+const STATE_OPEN = 'open';
+const STATE_OPENING = 'opening';
+const STATE_CLOSED = 'closed';
+const STATE_CLOSING = 'closing';
 
 class MPModal extends Component {
   get config() {
@@ -33,9 +20,7 @@ class MPModal extends Component {
       template,
       useShadowDom: true,
       defaultState: {
-        closed: true,
-        closing: false,
-        opening: false,
+        state: STATE_CLOSED,
       },
       helpers: {
         backdropClicked: () => {
@@ -61,22 +46,43 @@ class MPModal extends Component {
   }
 
   close() {
-    if (!(this.state.closing || this.state.closed)) {
-      this._animationCount = 0;
-      this.update({opening: false, closing: true});
+    switch(this.state.state) {
+      case STATE_CLOSED:
+      case STATE_CLOSING:
+        break;
+      case STATE_OPENING:
+        this.update({state: STATE_CLOSED});
+        break;
+      case STATE_OPEN:
+        this._pendingAnimations = ['fadeModalOut'];
+        if (this.config.helpers.getType() === 'modal') {
+          this._pendingAnimations.push('fadeOverlayOut');
+        }
+        this.update({state: STATE_CLOSING});
+        break;
     }
   }
 
   open() {
-    if (this.state.closed && !this.state.opening) {
-      this._animationCount = 0;
-      this.update({opening: true, closing: false, closed: false});
+    switch(this.state.state) {
+      case STATE_OPEN:
+      case STATE_OPENING:
+        break;
+      case STATE_CLOSING:
+        this.update({state: STATE_OPEN});
+        break;
+      case STATE_CLOSED:
+        this._pendingAnimations = ['fadeModalIn'];
+        if (this.config.helpers.getType() === 'modal') {
+          this._pendingAnimations.push('fadeOverlayIn');
+        }
+        this.update({state: STATE_OPENING});
+        break;
     }
   }
 
   attachedCallback() {
     super.attachedCallback(...arguments);
-    this._attached = true;
 
     // listen for escape keypress
     this.maybeCloseOnEscape = (e) => {
@@ -86,23 +92,26 @@ class MPModal extends Component {
     };
     document.body.addEventListener('keydown', this.maybeCloseOnEscape);
 
-    // use animation events to determine when the modal is done transitioning
-    // between open or closed states
-    this._animationCount = 0;
-    this._onAnimationStart = () => this._animationCount++;
-    this._onAnimationEnd = () => {
-      this._animationCount--;
-      if (this._animationCount === 0) {
-        if (this.state.opening) {
-          this.update({opening: false});
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'open'}}));
-        } else if (this.state.closing) {
-          this.update({closing: false, closed: true});
-          this.dispatchEvent(new CustomEvent('change', {detail: {state: 'closed'}}));
-        }
+    // transition between states after animations complete
+    this._onAnimationEnd = e => {
+      if (this._pendingAnimations.length === 0) {
+        return;
+      }
+      this._pendingAnimations = this._pendingAnimations.filter(anim => anim !== e.animationName);
+      if (this._pendingAnimations.length > 0) {
+        return;
+      }
+      switch(this.state.state) {
+        case STATE_OPENING:
+          this.update({state: STATE_OPEN});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: STATE_OPEN}}));
+          break;
+        case STATE_CLOSING:
+          this.update({state: STATE_CLOSED});
+          this.dispatchEvent(new CustomEvent('change', {detail: {state: STATE_CLOSED}}));
+          break;
       }
     };
-    onAnimationStart(this.el, this._onAnimationStart);
     onAnimationEnd(this.el, this._onAnimationEnd);
 
     // open the modal if "closed" is explicitly set to false
@@ -114,13 +123,12 @@ class MPModal extends Component {
   detachedCallback() {
     super.detachedCallback(...arguments);
     document.body.removeEventListener('keydown', this.maybeCloseOnEscape);
-    offAnimationStart(this.el, this._onAnimationStart);
     offAnimationEnd(this.el, this._onAnimationEnd);
   }
 
   attributeChangedCallback(name, oldVal, newVal) {
     super.attributeChangedCallback(...arguments);
-    if (this._attached && name === 'closed') {
+    if (this.initialized && name === 'closed') {
       if (newVal === 'true') {
         this.close();
       } else if (!newVal || newVal === 'false') {
@@ -128,7 +136,6 @@ class MPModal extends Component {
       }
     }
   }
-
 }
 
 if (window['mp-common-registered-components']['mp-modal'] !== true) {

--- a/lib/components/modals/modal.styl
+++ b/lib/components/modals/modal.styl
@@ -47,17 +47,25 @@
         position absolute
 
     .backdrop
-      animation fadeOverlayIn 300ms forwards
       background #45566d
       height 100%
-      opacity 0.9
       position fixed
       pointer-events auto
       width 100%
       z-index 1
 
+      &.opening
+        animation fadeOverlayIn 300ms forwards
+        opacity 0
+
+      &.open
+        opacity 0.9
+
       &.closing
-        animation-name fadeOverlayOut
+        animation fadeOverlayOut 300ms forwards
+
+      &.closed
+        opacity 0
 
     .wrapper
       display flex
@@ -70,19 +78,24 @@
       z-index 2
 
       .main
-        animation fadeModalIn 300ms forwards 100ms
         border-radius 6px
         box-shadow 0 1px 3px 0 rgba(1, 1, 1, 0.28)
         max-width 530px
-        opacity 0
         pointer-events auto
         position relative
         z-index 2
 
+        &.opening
+          animation fadeModalIn 300ms forwards 100ms
+          opacity 0
+
+        &.open
+          opacity 1
+
         &.closing
-          animation-name fadeModalOut
-          animation-delay 0ms
-          animation-speed 200mx
+          animation fadeModalOut 200ms forwards
+
+        &.closed
           opacity 0
 
         .close-btn

--- a/lib/components/tooltips/tooltip.js
+++ b/lib/components/tooltips/tooltip.js
@@ -1,5 +1,7 @@
 import { Component } from 'panel';
 
+import '../registration.js';
+
 import template from './tooltip.jade';
 
 import css from './tooltip.styl';

--- a/lib/components/utils.js
+++ b/lib/components/utils.js
@@ -7,5 +7,3 @@ export const onAnimationEnd = (el, callback) => {
 export const offAnimationEnd = (el, callback) => {
   ANIMATION_END_EVENTS.forEach(e => el.removeEventListener(e, callback));
 };
-
-

--- a/lib/components/utils.js
+++ b/lib/components/utils.js
@@ -1,0 +1,11 @@
+export const ANIMATION_END_EVENTS = ['webkitAnimationEnd', 'animationend', 'oAnimationEnd', 'MSAnimationEnd'];
+
+export const onAnimationEnd = (el, callback) => {
+  ANIMATION_END_EVENTS.forEach(e => el.addEventListener(e, callback));
+};
+
+export const offAnimationEnd = (el, callback) => {
+  ANIMATION_END_EVENTS.forEach(e => el.removeEventListener(e, callback));
+};
+
+

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "scripts": {
     "build": "babel lib -d build && cp -r build/report . && cp -r build/util .",
     "build-example": "webpack --context examples --config examples/webpack.config.js && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
-    "build-example-watch": "webpack --context examples --config examples/webpack.config.js -w",
     "lint": "eslint lib",
     "prepublish": "npm run build",
-    "test": "mocha --require babel-core/register test/**",
-    "integration-tests": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
+    "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
     "validate": "npm ls"
   },
   "repository": {
@@ -41,7 +39,6 @@
     "eslint": "^2.11.1",
     "expect.js": "^0.3.1",
     "js-beautify": "^1.6.3",
-    "mocha": "^2.5.3",
     "precommit-hook-eslint": "^3.0.0",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.14.0",
   "description": "Mixpanel shared JS",
   "scripts": {
-    "build": "babel lib -d build && cp -r build/report . && cp -r build/util . && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
-    "build-example": "webpack --context examples --config examples/webpack.config.js; ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
+    "build": "babel lib -d build && cp -r build/report . && cp -r build/util . && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
+    "build-example": "webpack --context examples --config examples/webpack.config.js && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
     "build-example-watch": "webpack --context examples --config examples/webpack.config.js -w",
     "lint": "eslint lib",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-example": "webpack --context examples --config examples/webpack.config.js && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
     "lint": "eslint lib",
     "prepublish": "npm run build",
-    "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
+    "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:99.0 wct --plugin local",
     "validate": "npm ls"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint lib",
     "prepublish": "npm run build",
     "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
+    "unit-test": "mocha --require babel-core/register",
     "validate": "npm ls"
   },
   "repository": {
@@ -39,6 +40,7 @@
     "eslint": "^2.11.1",
     "expect.js": "^0.3.1",
     "js-beautify": "^1.6.3",
+    "mocha": "^3.1.2",
     "precommit-hook-eslint": "^3.0.0",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.0",
   "description": "Mixpanel shared JS",
   "scripts": {
-    "build": "babel lib -d build && cp -r build/report . && cp -r build/util . && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
+    "build": "babel lib -d build && cp -r build/report . && cp -r build/util .",
     "build-example": "webpack --context examples --config examples/webpack.config.js && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
     "build-example-watch": "webpack --context examples --config examples/webpack.config.js -w",
     "lint": "eslint lib",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-example": "webpack --context examples --config examples/webpack.config.js && mkdir build/css && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
     "lint": "eslint lib",
     "prepublish": "npm run build",
-    "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:99.0 wct --plugin local",
+    "test": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
     "validate": "npm ls"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "0.14.0",
   "description": "Mixpanel shared JS",
   "scripts": {
-    "build": "babel lib -d build && cp -r build/report . && cp -r build/util .",
-    "build-example": "webpack",
-    "build-example-watch": "webpack -w",
+    "build": "babel lib -d build && cp -r build/report . && cp -r build/util . && ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
+    "build-example": "webpack --context examples --config examples/webpack.config.js; ./node_modules/stylus/bin/stylus --out build/css --compress stylesheets/*.styl",
+    "build-example-watch": "webpack --context examples --config examples/webpack.config.js -w",
     "lint": "eslint lib",
     "prepublish": "npm run build",
-    "test": "mocha --require babel-core/register",
+    "test": "mocha --require babel-core/register test/**",
+    "integration-tests": "webpack --context test --config test/webpack.config.js; DISPLAY=:30 wct --plugin local",
     "validate": "npm ls"
   },
   "repository": {
@@ -47,6 +48,7 @@
     "stylus-loader": "^2.1.0",
     "virtual-jade": "^0.3.3",
     "virtual-jade-loader": "^0.3.2",
+    "web-component-tester": "^4.3.4",
     "webcomponents.js": "^0.7.22",
     "webpack": "^1.13.1"
   },

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -10,11 +10,10 @@ const VISIBILITY_OPENING = 'opening';
 const VISIBILITY_CLOSED = 'closed';
 const VISIBILITY_CLOSING = 'closing';
 
-describe('Test mixpanel-common modal component', () => {
-  let modal;
-  beforeEach(done => {
-    modal = document.createElement('mp-modal');
-    document.body.appendChild(modal);
+describe('Test mixpanel-common modal component', function() {
+  beforeEach(function(done) {
+    this.modal = document.createElement('mp-modal');
+    document.body.appendChild(this.modal);
     window.requestAnimationFrame(() => done());
   });
 
@@ -22,118 +21,118 @@ describe('Test mixpanel-common modal component', () => {
     document.body.innerHTML = '';
   });
 
-  describe('imperative API', () => {
-    it('opens when "open()" is called', () => {
-      modal.open();
-      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
+  describe('imperative API', function() {
+    it('opens when "open()" is called', function() {
+      this.modal.open();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
-    it('closes when "close()" is called', () => {
-      modal.update({visibility: VISIBILITY_OPEN});
-      modal.close();
-      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
+    it('closes when "close()" is called', function() {
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      this.modal.close();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
 
-    it('opens when "open()" is called before close animation completes', () => {
-      modal.update({visibility: VISIBILITY_OPEN});
-      modal.close();
-      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
-      modal.open();
-      expect(modal.state.visibility).to.equal(VISIBILITY_OPEN);
+    it('opens when "open()" is called before close animation completes', function() {
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      this.modal.close();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSING);
+      this.modal.open();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_OPEN);
     });
 
-    it('closes when "close()" is called before open animation completes', () => {
-      modal.open();
-      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
-      modal.close();
-      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSED);
-    });
-  });
-
-  describe('"closed" attribute', () => {
-   it('immediately opens when set to "false" before it is attached', () => {
-      document.body.removeChild(modal);
-      modal.setAttribute('closed', 'false');
-      document.body.appendChild(modal);
-      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
-    });
-
-    it('opens when set to "false"', () => {
-      modal.setAttribute('closed', 'false');
-      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
-    });
-
-    it('closes when set to "true"', () => {
-      modal.setAttribute('closed', 'false');
-      modal.update({visibility: VISIBILITY_OPEN});
-      modal.setAttribute('closed', 'true');
-      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
+    it('closes when "close()" is called before open animation completes', function() {
+      this.modal.open();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_OPENING);
+      this.modal.close();
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSED);
     });
   });
 
-  describe('"closeable" attribute', () => {
-    it('does not close when clicked outside when not enabled', done => {
-      modal.setAttribute('closeable', 'false');
-      modal.update({visibility: VISIBILITY_OPEN});
-      window.requestAnimationFrame(() => {
-        modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-        expect(modal.state.visibility).to.equal(VISIBILITY_OPEN);
-        done();
-      });
+  describe('"closed" attribute', function() {
+   it('immediately opens when set to "false" before it is attached', function() {
+      document.body.removeChild(this.modal);
+      this.modal.setAttribute('closed', 'false');
+      document.body.appendChild(this.modal);
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
-    it('closes when clicked outside when enabled', done => {
-      modal.setAttribute('closeable', 'true');
-      modal.update({visibility: VISIBILITY_OPEN});
-      window.requestAnimationFrame(() => {
-        modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-        expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
-        done();
-      });
+    it('opens when set to "false"', function() {
+      this.modal.setAttribute('closed', 'false');
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
-    it('does not have a close button when not enabled', done => {
-      modal.setAttribute('closeable', 'false');
-      modal.update({visibility: VISIBILITY_OPEN});
-      window.requestAnimationFrame(() => {
-        expect(modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
-        done();
-      });
-    });
-
-    it('has a close button when enabled', done => {
-      modal.setAttribute('closeable', 'true');
-      modal.update({visibility: VISIBILITY_OPEN});
-      window.requestAnimationFrame(() => {
-        expect(modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
-        done();
-      });
+    it('closes when set to "true"', function() {
+      this.modal.setAttribute('closed', 'false');
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      this.modal.setAttribute('closed', 'true');
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
   });
 
-  describe('"modal-type" attribute', () => {
-    it('does take over the screen if the "modal-type" is modal', done => {
-      modal.setAttribute('modal-type', 'modal');
-      modal.update({visibility: VISIBILITY_OPEN});
+  describe('"closeable" attribute', function() {
+    it('does not close when clicked outside when not enabled', function(done) {
+      this.modal.setAttribute('closeable', 'false');
+      this.modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
-        expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
+        this.modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+        expect(this.modal.state.visibility).to.equal(VISIBILITY_OPEN);
         done();
       });
     });
 
-    it('does not take over the screen if the "modal-type" is popup', done => {
-      modal.setAttribute('modal-type', 'popup');
-      modal.update({visibility: VISIBILITY_OPEN});
+    it('closes when clicked outside when enabled', function(done) {
+      this.modal.setAttribute('closeable', 'true');
+      this.modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
-        expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
+        this.modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+        expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSING);
+        done();
+      });
+    });
+
+    it('does not have a close button when not enabled', function(done) {
+      this.modal.setAttribute('closeable', 'false');
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      window.requestAnimationFrame(() => {
+        expect(this.modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
+        done();
+      });
+    });
+
+    it('has a close button when enabled', function(done) {
+      this.modal.setAttribute('closeable', 'true');
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      window.requestAnimationFrame(() => {
+        expect(this.modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
         done();
       });
     });
   });
 
-  describe('life-cycle', () => {
+  describe('"modal-type" attribute', function() {
+    it('does take over the screen if the "modal-type" is modal', function(done) {
+      this.modal.setAttribute('modal-type', 'modal');
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      window.requestAnimationFrame(() => {
+        expect(this.modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
+        done();
+      });
+    });
 
-    it('animates open', done => {
+    it('does not take over the screen if the "modal-type" is popup', function(done) {
+      this.modal.setAttribute('modal-type', 'popup');
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      window.requestAnimationFrame(() => {
+        expect(this.modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
+        done();
+      });
+    });
+  });
+
+  describe('life-cycle', function() {
+
+    it('animates open', function(done) {
       const animations = ['fadeModalIn', 'fadeOverlayIn'];
       const animationEnd = e => {
         const idx = animations.indexOf(e.animationName)
@@ -142,16 +141,16 @@ describe('Test mixpanel-common modal component', () => {
         }
         animations.splice(idx, 1);
         if (animations.length === 0) {
-          offAnimationEnd(modal, animationEnd);
+          offAnimationEnd(this.modal, animationEnd);
           done();
         }
       };
-      onAnimationEnd(modal, animationEnd);
-      modal.open();
+      onAnimationEnd(this.modal, animationEnd);
+      this.modal.open();
     });
 
-    it('animates closed', done => {
-      modal.update({visibility: VISIBILITY_OPEN});
+    it('animates closed', function(done) {
+      this.modal.update({visibility: VISIBILITY_OPEN});
       const animations = ['fadeModalOut', 'fadeOverlayOut'];
       const animationEnd = e => {
         const idx = animations.indexOf(e.animationName)
@@ -160,66 +159,66 @@ describe('Test mixpanel-common modal component', () => {
         }
         animations.splice(idx, 1);
         if (animations.length === 0) {
-          offAnimationEnd(modal, animationEnd);
+          offAnimationEnd(this.modal, animationEnd);
           done();
         }
       };
-      onAnimationEnd(modal, animationEnd);
-      modal.close();
+      onAnimationEnd(this.modal, animationEnd);
+      this.modal.close();
     });
 
-    it('fires "change" event when open is complete', done => {
-      modal.addEventListener('change', e => {
+    it('fires "change" event when open is complete', function(done) {
+      this.modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_OPEN) {
           done();
         }
       });
-      modal.open();
+      this.modal.open();
     });
 
-    it('fires "change" event when close is complete', done => {
-      modal.update({visibility: VISIBILITY_OPEN});
-      modal.addEventListener('change', e => {
+    it('fires "change" event when close is complete', function(done) {
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      this.modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_CLOSED) {
           done();
         }
       });
-      modal.close();
+      this.modal.close();
     });
   });
 
-  describe('full integration', () => {
-    it('attaches in a closed state', () => {
-      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSED);
+  describe('full integration', function() {
+    it('attaches in a closed state', function() {
+      expect(this.modal.state.visibility).to.equal(VISIBILITY_CLOSED);
     });
 
-    it('is visible after "open()" is called', done => {
-      modal.addEventListener('change', e => {
+    it('is visible after "open()" is called', function(done) {
+      this.modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_OPEN) {
           window.requestAnimationFrame(() => {
-            const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+            const modalRoot = this.modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(false);
             expect(window.getComputedStyle(modalRoot).display).to.equal('block');
             done();
           });
         }
       });
-      modal.open();
+      this.modal.open();
     });
 
-    it('is invisible after "close()" is called', done => {
-      modal.update({visibility: VISIBILITY_OPEN});
-      modal.addEventListener('change', e => {
+    it('is invisible after "close()" is called', function(done) {
+      this.modal.update({visibility: VISIBILITY_OPEN});
+      this.modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_CLOSED) {
           window.requestAnimationFrame(() => {
-            const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+            const modalRoot = this.modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);
             expect(window.getComputedStyle(modalRoot).display).to.equal('none');
             done();
           });
         }
       });
-      modal.close();
+      this.modal.close();
     });
   });
 });

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -5,10 +5,10 @@ import 'webcomponents.js/webcomponents';
 import '../../lib/components/modals/modal'
 import { onAnimationEnd, offAnimationEnd } from '../../lib/components/utils';
 
-const STATE_OPEN = 'open';
-const STATE_OPENING = 'opening';
-const STATE_CLOSED = 'closed';
-const STATE_CLOSING = 'closing';
+const VISIBILITY_OPEN = 'open';
+const VISIBILITY_OPENING = 'opening';
+const VISIBILITY_CLOSED = 'closed';
+const VISIBILITY_CLOSING = 'closing';
 
 describe('Test mixpanel-common modal component', () => {
   let modal;
@@ -25,28 +25,28 @@ describe('Test mixpanel-common modal component', () => {
   describe('test imperative API', () => {
     it('opens when "open()" is called', () => {
       modal.open();
-      expect(modal.state.state).to.equal(STATE_OPENING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
     it('closes when "close()" is called', () => {
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       modal.close();
-      expect(modal.state.state).to.equal(STATE_CLOSING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
 
     it('opens when "open()" is called before close animation completes', () => {
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       modal.close();
-      expect(modal.state.state).to.equal(STATE_CLOSING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
       modal.open();
-      expect(modal.state.state).to.equal(STATE_OPEN);
+      expect(modal.state.visibility).to.equal(VISIBILITY_OPEN);
     });
 
     it('closes when "close()" is called before open animation completes', () => {
       modal.open();
-      expect(modal.state.state).to.equal(STATE_OPENING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
       modal.close();
-      expect(modal.state.state).to.equal(STATE_CLOSED);
+      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSED);
     });
   });
 
@@ -55,46 +55,46 @@ describe('Test mixpanel-common modal component', () => {
       document.body.removeChild(modal);
       modal.setAttribute('closed', 'false');
       document.body.appendChild(modal);
-      expect(modal.state.state).to.equal(STATE_OPENING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
     it('opens when set to "false"', () => {
       modal.setAttribute('closed', 'false');
-      expect(modal.state.state).to.equal(STATE_OPENING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
     });
 
     it('closes when set to "true"', () => {
       modal.setAttribute('closed', 'false');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       modal.setAttribute('closed', 'true');
-      expect(modal.state.state).to.equal(STATE_CLOSING);
+      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
   });
 
   describe('test "closeable" attribute', () => {
     it('does not close when clicked outside when not enabled', done => {
       modal.setAttribute('closeable', 'false');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-        expect(modal.state.state).to.equal(STATE_OPEN);
+        expect(modal.state.visibility).to.equal(VISIBILITY_OPEN);
         done();
       });
     });
 
     it('closes when clicked outside when enabled', done => {
       modal.setAttribute('closeable', 'true');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-        expect(modal.state.state).to.equal(STATE_CLOSING);
+        expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
         done();
       });
     });
 
     it('does not have a close button when not enabled', done => {
       modal.setAttribute('closeable', 'false');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
         done();
@@ -103,7 +103,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('has a close button when enabled', done => {
       modal.setAttribute('closeable', 'true');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
         done();
@@ -114,7 +114,7 @@ describe('Test mixpanel-common modal component', () => {
   describe('test "modal-type" attribute', () => {
     it('does take over the screen if the "modal-type" is modal', done => {
       modal.setAttribute('modal-type', 'modal');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
         done();
@@ -123,7 +123,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('does not take over the screen if the "modal-type" is popup', done => {
       modal.setAttribute('modal-type', 'popup');
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
         done();
@@ -151,7 +151,7 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('animates closed', done => {
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       const animations = ['fadeModalOut', 'fadeOverlayOut'];
       const animationEnd = e => {
         const idx = animations.indexOf(e.animationName)
@@ -170,7 +170,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('fires "change" event when open is complete', done => {
       modal.addEventListener('change', e => {
-        if (e.detail.state === STATE_OPEN) {
+        if (e.detail.state === VISIBILITY_OPEN) {
           done();
         }
       });
@@ -178,9 +178,9 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('fires "change" event when close is complete', done => {
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       modal.addEventListener('change', e => {
-        if (e.detail.state === STATE_CLOSED) {
+        if (e.detail.state === VISIBILITY_CLOSED) {
           done();
         }
       });
@@ -190,12 +190,12 @@ describe('Test mixpanel-common modal component', () => {
 
   describe('test full integration', () => {
     it('attaches in a closed state', () => {
-      expect(modal.state.state).to.equal(STATE_CLOSED);
+      expect(modal.state.visibility).to.equal(VISIBILITY_CLOSED);
     });
 
     it('is visible after "open()" is called', done => {
       modal.addEventListener('change', e => {
-        if (e.detail.state === STATE_OPEN) {
+        if (e.detail.state === VISIBILITY_OPEN) {
           window.requestAnimationFrame(() => {
             const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(false);
@@ -208,9 +208,9 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('is invisible after "close()" is called', done => {
-      modal.update({state: STATE_OPEN});
+      modal.update({state: VISIBILITY_OPEN});
       modal.addEventListener('change', e => {
-        if (e.detail.state === STATE_CLOSED) {
+        if (e.detail.state === VISIBILITY_CLOSED) {
           window.requestAnimationFrame(() => {
             const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -1,5 +1,6 @@
 /* global beforeEach, describe, it */
 import expect from 'expect.js';
+import 'webcomponents.js/webcomponents';
 
 import '../../lib/components/modals/modal'
 import { onAnimationEnd, offAnimationEnd } from '../../lib/components/utils';
@@ -11,9 +12,10 @@ const STATE_CLOSING = 'closing';
 
 describe('Test mixpanel-common modal component', () => {
   let modal;
-  beforeEach(() => {
+  beforeEach(done => {
     modal = document.createElement('mp-modal');
     document.body.appendChild(modal);
+    window.requestAnimationFrame(() => done());
   });
 
   afterEach(() => {
@@ -194,12 +196,12 @@ describe('Test mixpanel-common modal component', () => {
     it('is visible after "open()" is called', done => {
       modal.addEventListener('change', e => {
         if (e.detail.state === STATE_OPEN) {
-          setTimeout(() => {
+          window.requestAnimationFrame(() => {
             const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(false);
             expect(window.getComputedStyle(modalRoot).display).to.equal('block');
             done();
-          }, 0);
+          });
         }
       });
       modal.open();
@@ -209,12 +211,12 @@ describe('Test mixpanel-common modal component', () => {
       modal.update({state: STATE_OPEN});
       modal.addEventListener('change', e => {
         if (e.detail.state === STATE_CLOSED) {
-          setTimeout(() => {
+          window.requestAnimationFrame(() => {
             const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
             expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);
             expect(window.getComputedStyle(modalRoot).display).to.equal('none');
             done();
-          }, 0);
+          });
         }
       });
       modal.close();

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -29,13 +29,13 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('closes when "close()" is called', () => {
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       modal.close();
       expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
 
     it('opens when "open()" is called before close animation completes', () => {
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       modal.close();
       expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
       modal.open();
@@ -65,7 +65,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('closes when set to "true"', () => {
       modal.setAttribute('closed', 'false');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       modal.setAttribute('closed', 'true');
       expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
     });
@@ -74,7 +74,7 @@ describe('Test mixpanel-common modal component', () => {
   describe('"closeable" attribute', () => {
     it('does not close when clicked outside when not enabled', done => {
       modal.setAttribute('closeable', 'false');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
         expect(modal.state.visibility).to.equal(VISIBILITY_OPEN);
@@ -84,7 +84,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('closes when clicked outside when enabled', done => {
       modal.setAttribute('closeable', 'true');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
         expect(modal.state.visibility).to.equal(VISIBILITY_CLOSING);
@@ -94,7 +94,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('does not have a close button when not enabled', done => {
       modal.setAttribute('closeable', 'false');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
         done();
@@ -103,7 +103,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('has a close button when enabled', done => {
       modal.setAttribute('closeable', 'true');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
         done();
@@ -114,7 +114,7 @@ describe('Test mixpanel-common modal component', () => {
   describe('"modal-type" attribute', () => {
     it('does take over the screen if the "modal-type" is modal', done => {
       modal.setAttribute('modal-type', 'modal');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
         done();
@@ -123,7 +123,7 @@ describe('Test mixpanel-common modal component', () => {
 
     it('does not take over the screen if the "modal-type" is popup', done => {
       modal.setAttribute('modal-type', 'popup');
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
         done();
@@ -151,7 +151,7 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('animates closed', done => {
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       const animations = ['fadeModalOut', 'fadeOverlayOut'];
       const animationEnd = e => {
         const idx = animations.indexOf(e.animationName)
@@ -178,7 +178,7 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('fires "change" event when close is complete', done => {
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_CLOSED) {
           done();
@@ -208,7 +208,7 @@ describe('Test mixpanel-common modal component', () => {
     });
 
     it('is invisible after "close()" is called', done => {
-      modal.update({state: VISIBILITY_OPEN});
+      modal.update({visibility: VISIBILITY_OPEN});
       modal.addEventListener('change', e => {
         if (e.detail.state === VISIBILITY_CLOSED) {
           window.requestAnimationFrame(() => {

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -22,7 +22,7 @@ describe('Test mixpanel-common modal component', () => {
     document.body.innerHTML = '';
   });
 
-  describe('test imperative API', () => {
+  describe('imperative API', () => {
     it('opens when "open()" is called', () => {
       modal.open();
       expect(modal.state.visibility).to.equal(VISIBILITY_OPENING);
@@ -50,7 +50,7 @@ describe('Test mixpanel-common modal component', () => {
     });
   });
 
-  describe('test "closed" attribute', () => {
+  describe('"closed" attribute', () => {
    it('immediately opens when set to "false" before it is attached', () => {
       document.body.removeChild(modal);
       modal.setAttribute('closed', 'false');
@@ -71,7 +71,7 @@ describe('Test mixpanel-common modal component', () => {
     });
   });
 
-  describe('test "closeable" attribute', () => {
+  describe('"closeable" attribute', () => {
     it('does not close when clicked outside when not enabled', done => {
       modal.setAttribute('closeable', 'false');
       modal.update({state: VISIBILITY_OPEN});
@@ -111,7 +111,7 @@ describe('Test mixpanel-common modal component', () => {
     });
   });
 
-  describe('test "modal-type" attribute', () => {
+  describe('"modal-type" attribute', () => {
     it('does take over the screen if the "modal-type" is modal', done => {
       modal.setAttribute('modal-type', 'modal');
       modal.update({state: VISIBILITY_OPEN});
@@ -131,7 +131,7 @@ describe('Test mixpanel-common modal component', () => {
     });
   });
 
-  describe('test life-cycle', () => {
+  describe('life-cycle', () => {
 
     it('animates open', done => {
       const animations = ['fadeModalIn', 'fadeOverlayIn'];
@@ -188,7 +188,7 @@ describe('Test mixpanel-common modal component', () => {
     });
   });
 
-  describe('test full integration', () => {
+  describe('full integration', () => {
     it('attaches in a closed state', () => {
       expect(modal.state.visibility).to.equal(VISIBILITY_CLOSED);
     });

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -1,34 +1,15 @@
 /* global beforeEach, describe, it */
 import expect from 'expect.js';
 
-import '../../lib/components/modals/modal.js'
+import '../../lib/components/modals/modal'
+import { onAnimationEnd, offAnimationEnd } from '../../lib/components/utils';
+
+const STATE_OPEN = 'open';
+const STATE_OPENING = 'opening';
+const STATE_CLOSED = 'closed';
+const STATE_CLOSING = 'closing';
 
 describe('Test mixpanel-common modal component', () => {
-
-  const expectOpen = () => {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
-        expect(modal.state.closed).to.equal(false);
-        expect(modalRoot.classList.contains('mp-modal-close')).to.equal(false);
-        expect(window.getComputedStyle(modalRoot).display).to.equal('block');
-        resolve();
-      }, 0);
-    });
-  };
-
-  const expectClosed = () => {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
-        expect(modal.state.closed).to.equal(true);
-        expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);
-        expect(window.getComputedStyle(modalRoot).display).to.equal('none');
-        resolve();
-      }, 0);
-    });
-  };
-
   let modal;
   beforeEach(() => {
     modal = document.createElement('mp-modal');
@@ -39,128 +20,204 @@ describe('Test mixpanel-common modal component', () => {
     document.body.removeChild(modal);
   });
 
-  it('attaches in a closed state', done => {
-    expectClosed().then(done);
-  });
-
-  it('immediately opens when the "closed" attribute is "false" before it is attached', done => {
-    document.body.removeChild(modal);
-    modal.setAttribute('closed', 'false');
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
-        expectOpen().then(done);
-      }
+  describe('test imperative API', () => {
+    it('opens when "open()" is called', () => {
+      modal.open();
+      expect(modal.state.state).to.equal(STATE_OPENING);
     });
-    document.body.appendChild(modal);
-  });
 
-  it('opens when "open()" is called', done => {
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
-        expectOpen().then(done);
-      }
+    it('closes when "close()" is called', () => {
+      modal.update({state: STATE_OPEN});
+      modal.close();
+      expect(modal.state.state).to.equal(STATE_CLOSING);
     });
-    modal.open();
-  });
 
-  it('closes when "close()" is called', done => {
-    modal.open();
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'closed') {
-        expectClosed().then(done);
-      }
+    it('opens when "open()" is called before close animation completes', () => {
+      modal.update({state: STATE_OPEN});
+      modal.close();
+      expect(modal.state.state).to.equal(STATE_CLOSING);
+      modal.open();
+      expect(modal.state.state).to.equal(STATE_OPEN);
     });
-    modal.close();
-  });
 
-  it('opens when the "closed" attribute is set to "false"', done => {
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
-        expectOpen().then(done);
-      }
+    it('closes when "close()" is called before open animation completes', () => {
+      modal.open();
+      expect(modal.state.state).to.equal(STATE_OPENING);
+      modal.close();
+      expect(modal.state.state).to.equal(STATE_CLOSED);
     });
-    modal.setAttribute('closed', 'false');
   });
 
-  it('closes when the "closed" attribute is set to "true"', done => {
-    modal.setAttribute('closed', 'false');
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'closed') {
-        expectClosed().then(done);
-      }
+  describe('test "closed" attribute', () => {
+   it('immediately opens when set to "false" before it is attached', () => {
+      document.body.removeChild(modal);
+      modal.setAttribute('closed', 'false');
+      document.body.appendChild(modal);
+      expect(modal.state.state).to.equal(STATE_OPENING);
     });
-    modal.setAttribute('closed', 'true');
-  });
 
-  it('does not close when clicked outside by default', done => {
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
-        expectOpen().then(() => {
-          modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-          setTimeout(function() {
-            expectOpen().then(done);
-          }, 1000);
-        });
-      }
+    it('opens when set to "false"', () => {
+      modal.setAttribute('closed', 'false');
+      expect(modal.state.state).to.equal(STATE_OPENING);
     });
-    modal.open();
-  });
 
-  it('closes when clicked outside when the "closeable" attribute is enabled', done => {
-    modal.addEventListener('change', e => {
-      switch(e.detail.state) {
-        case 'open':
-          modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
-          break;
-        case 'closed':
-          expectClosed().then(done);
-          break;
-      }
+    it('closes when set to "true"', () => {
+      modal.setAttribute('closed', 'false');
+      modal.update({state: STATE_OPEN});
+      modal.setAttribute('closed', 'true');
+      expect(modal.state.state).to.equal(STATE_CLOSING);
     });
-    modal.setAttribute('closeable', 'true');
-    modal.setAttribute('closed', 'false');
   });
 
-  it('does not have a close button by default', done => {
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
+  describe('test "closeable" attribute', () => {
+    it('does not close when clicked outside when not enabled', done => {
+      modal.setAttribute('closeable', 'false');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
+        modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+        expect(modal.state.state).to.equal(STATE_OPEN);
+        done();
+      });
+    });
+
+    it('closes when clicked outside when enabled', done => {
+      modal.setAttribute('closeable', 'true');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
+        modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+        expect(modal.state.state).to.equal(STATE_CLOSING);
+        done();
+      });
+    });
+
+    it('does not have a close button when not enabled', done => {
+      modal.setAttribute('closeable', 'false');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
         done();
-      }
+      });
     });
-    modal.setAttribute('closed', 'false');
-  });
 
-  it('has a close button when the "closeable" attribute is enabled', done => {
-    modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
+    it('has a close button when enabled', done => {
+      modal.setAttribute('closeable', 'true');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
         done();
-      }
+      });
     });
-    modal.setAttribute('closeable', 'true');
-    modal.setAttribute('closed', 'false');
   });
 
-  it('does takes over the screen if the "modal-type" is modal', done => {
-      modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
+  describe('test "modal-type" attribute', () => {
+    it('does take over the screen if the "modal-type" is modal', done => {
+      modal.setAttribute('modal-type', 'modal');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
         done();
-      }
+      });
     });
-    modal.setAttribute('modal-type', 'modal');
-    modal.setAttribute('closed', 'false');
-  });
 
-  it('does not take over the screen if the "modal-type" is popup', done => {
-      modal.addEventListener('change', e => {
-      if (e.detail.state === 'open') {
+    it('does not take over the screen if the "modal-type" is popup', done => {
+      modal.setAttribute('modal-type', 'popup');
+      modal.update({state: STATE_OPEN});
+      window.requestAnimationFrame(() => {
         expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
         done();
-      }
+      });
     });
-    modal.setAttribute('modal-type', 'popup');
-    modal.setAttribute('closed', 'false');
+  });
+
+  describe('test life-cycle', () => {
+
+    it('animates open', done => {
+      const animations = ['fadeModalIn', 'fadeOverlayIn'];
+      const animationEnd = e => {
+        const idx = animations.indexOf(e.animationName)
+        if (idx === -1) {
+          throw Error(`Unexpected animation '${e.animationName}'`);
+        }
+        animations.splice(idx, 1);
+        if (animations.length === 0) {
+          offAnimationEnd(modal, animationEnd);
+          done();
+        }
+      };
+      onAnimationEnd(modal, animationEnd);
+      modal.open();
+    });
+
+    it('animates closed', done => {
+      modal.update({state: STATE_OPEN});
+      const animations = ['fadeModalOut', 'fadeOverlayOut'];
+      const animationEnd = e => {
+        const idx = animations.indexOf(e.animationName)
+        if (idx === -1) {
+          throw Error(`Unexpected animation '${e.animationName}'`);
+        }
+        animations.splice(idx, 1);
+        if (animations.length === 0) {
+          offAnimationEnd(modal, animationEnd);
+          done();
+        }
+      };
+      onAnimationEnd(modal, animationEnd);
+      modal.close();
+    });
+
+    it('fires "change" event when open is complete', done => {
+      modal.addEventListener('change', e => {
+        if (e.detail.state === STATE_OPEN) {
+          done();
+        }
+      });
+      modal.open();
+    });
+
+    it('fires "change" event when close is complete', done => {
+      modal.update({state: STATE_OPEN});
+      modal.addEventListener('change', e => {
+        if (e.detail.state === STATE_CLOSED) {
+          done();
+        }
+      });
+      modal.close();
+    });
+  });
+
+  describe('test full integration', () => {
+    it('attaches in a closed state', () => {
+      expect(modal.state.state).to.equal(STATE_CLOSED);
+    });
+
+    it('is visible after "open()" is called', done => {
+      modal.addEventListener('change', e => {
+        if (e.detail.state === STATE_OPEN) {
+          setTimeout(() => {
+            const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+            expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(false);
+            expect(window.getComputedStyle(modalRoot).display).to.equal('block');
+            done();
+          }, 0);
+        }
+      });
+      modal.open();
+    });
+
+    it('is invisible after "close()" is called', done => {
+      modal.update({state: STATE_OPEN});
+      modal.addEventListener('change', e => {
+        if (e.detail.state === STATE_CLOSED) {
+          setTimeout(() => {
+            const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+            expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);
+            expect(window.getComputedStyle(modalRoot).display).to.equal('none');
+            done();
+          }, 0);
+        }
+      });
+      modal.close();
+    });
   });
 });

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -19,7 +19,7 @@ describe('Test mixpanel-common modal component', () => {
   });
 
   afterEach(() => {
-    document.body.removeChild(modal);
+    document.body.innerHTML = '';
   });
 
   describe('test imperative API', () => {

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -12,13 +12,10 @@ const VISIBILITY_CLOSING = 'closing';
 
 describe('Test mixpanel-common modal component', function() {
   beforeEach(function(done) {
+    document.body.innerHTML = '';
     this.modal = document.createElement('mp-modal');
     document.body.appendChild(this.modal);
     window.requestAnimationFrame(() => done());
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = '';
   });
 
   describe('imperative API', function() {

--- a/test/components/modal.js
+++ b/test/components/modal.js
@@ -1,0 +1,166 @@
+/* global beforeEach, describe, it */
+import expect from 'expect.js';
+
+import '../../lib/components/modals/modal.js'
+
+describe('Test mixpanel-common modal component', () => {
+
+  const expectOpen = () => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+        expect(modal.state.closed).to.equal(false);
+        expect(modalRoot.classList.contains('mp-modal-close')).to.equal(false);
+        expect(window.getComputedStyle(modalRoot).display).to.equal('block');
+        resolve();
+      }, 0);
+    });
+  };
+
+  const expectClosed = () => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        const modalRoot = modal.shadowRoot.querySelector('.mp-modal-stage');
+        expect(modal.state.closed).to.equal(true);
+        expect(modalRoot.classList.contains('mp-modal-closed')).to.equal(true);
+        expect(window.getComputedStyle(modalRoot).display).to.equal('none');
+        resolve();
+      }, 0);
+    });
+  };
+
+  let modal;
+  beforeEach(() => {
+    modal = document.createElement('mp-modal');
+    document.body.appendChild(modal);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(modal);
+  });
+
+  it('attaches in a closed state', done => {
+    expectClosed().then(done);
+  });
+
+  it('immediately opens when the "closed" attribute is "false" before it is attached', done => {
+    document.body.removeChild(modal);
+    modal.setAttribute('closed', 'false');
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expectOpen().then(done);
+      }
+    });
+    document.body.appendChild(modal);
+  });
+
+  it('opens when "open()" is called', done => {
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expectOpen().then(done);
+      }
+    });
+    modal.open();
+  });
+
+  it('closes when "close()" is called', done => {
+    modal.open();
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'closed') {
+        expectClosed().then(done);
+      }
+    });
+    modal.close();
+  });
+
+  it('opens when the "closed" attribute is set to "false"', done => {
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expectOpen().then(done);
+      }
+    });
+    modal.setAttribute('closed', 'false');
+  });
+
+  it('closes when the "closed" attribute is set to "true"', done => {
+    modal.setAttribute('closed', 'false');
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'closed') {
+        expectClosed().then(done);
+      }
+    });
+    modal.setAttribute('closed', 'true');
+  });
+
+  it('does not close when clicked outside by default', done => {
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expectOpen().then(() => {
+          modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+          setTimeout(function() {
+            expectOpen().then(done);
+          }, 1000);
+        });
+      }
+    });
+    modal.open();
+  });
+
+  it('closes when clicked outside when the "closeable" attribute is enabled', done => {
+    modal.addEventListener('change', e => {
+      switch(e.detail.state) {
+        case 'open':
+          modal.shadowRoot.querySelector('.mp-modal-backdrop').dispatchEvent(new MouseEvent('click'));
+          break;
+        case 'closed':
+          expectClosed().then(done);
+          break;
+      }
+    });
+    modal.setAttribute('closeable', 'true');
+    modal.setAttribute('closed', 'false');
+  });
+
+  it('does not have a close button by default', done => {
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expect(modal.shadowRoot.querySelector('mp-modal-close-btn')).to.equal(null);
+        done();
+      }
+    });
+    modal.setAttribute('closed', 'false');
+  });
+
+  it('has a close button when the "closeable" attribute is enabled', done => {
+    modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expect(modal.shadowRoot.querySelector('.mp-modal-close-btn')).to.not.equal(null);
+        done();
+      }
+    });
+    modal.setAttribute('closeable', 'true');
+    modal.setAttribute('closed', 'false');
+  });
+
+  it('does takes over the screen if the "modal-type" is modal', done => {
+      modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.not.equal(null);
+        done();
+      }
+    });
+    modal.setAttribute('modal-type', 'modal');
+    modal.setAttribute('closed', 'false');
+  });
+
+  it('does not take over the screen if the "modal-type" is popup', done => {
+      modal.addEventListener('change', e => {
+      if (e.detail.state === 'open') {
+        expect(modal.shadowRoot.querySelector('.mp-modal-backdrop')).to.equal(null);
+        done();
+      }
+    });
+    modal.setAttribute('modal-type', 'popup');
+    modal.setAttribute('closed', 'false');
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,15 @@
+
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../node_modules/webcomponents.js/webcomponents.js"></script>
+    <script>WCT = {"root":"/components/"};</script>
+    <script src="/web-component-tester/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      WCT.loadSuites(["./build/components/modal.js"]);
+    </script>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,10 @@
   </head>
   <body>
     <script>
-      WCT.loadSuites(["./build/components/modal.js"]);
+      WCT.loadSuites([
+        "./build/util.js",
+        "./build/components/modal.js"
+      ]);
     </script>
   </body>
 </html>

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -2,7 +2,8 @@ var path = require('path');
 
 var webpackConfig = {
   entry: {
-    'components/modal': './components/modal.js'
+    'components/modal': './components/modal.js',
+    'util': './util.js'
   },
   output: {
     filename: '[name].js',

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,0 +1,38 @@
+var path = require('path');
+
+var webpackConfig = {
+  entry: {
+    'components/modal': './components/modal.js'
+  },
+  output: {
+    filename: '[name].js',
+    path: path.join(__dirname, '/build/')
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015'],
+        },
+      },
+      {
+        test: /\.styl$/,
+        exclude: /node_modules/,
+        loader: 'css-loader!autoprefixer-loader!stylus-loader',
+      },
+      {
+        test: /\.jade$/,
+        exclude: /node_modules/,
+        loader: 'babel?presets[]=es2015&babelrc=false!virtual-jade-loader',
+      },
+    ],
+  },
+  resolveLoader: {
+    root: path.join(__dirname, 'node_modules'),
+  },
+};
+
+module.exports = webpackConfig;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -24,7 +24,11 @@
           "browserName": "safari",
           "version": "latest",
           "platform": "OS X 10.11"
-        }
+        }, {
+          "browserName": "microsoftedge",
+          "version": "latest",
+          "platform": "Windows 10"
+        },
       ]
     }
   }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -28,7 +28,7 @@
           "browserName": "microsoftedge",
           "version": "latest",
           "platform": "Windows 10"
-        },
+        }
       ]
     }
   }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,30 @@
+{
+  "verbose": false,
+  "suites": ["test/build/components/modal.js"],
+  "plugins": {
+    "local": {
+      "disabled": true,
+      "browsers": [
+        "chrome"
+      ]
+    },
+    "sauce": {
+      "disabled": true,
+      "browsers": [
+        {
+          "browserName": "chrome",
+          "version": "latest",
+          "platform": "OS X 10.11"
+        }, {
+          "browserName": "firefox",
+          "version": "latest",
+          "platform": "OS X 10.11"
+        }, {
+          "browserName": "safari",
+          "version": "latest",
+          "platform": "OS X 10.11"
+        }
+      ]
+    }
+  }
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,6 +1,6 @@
 {
   "verbose": false,
-  "suites": ["test/build/components/modal.js"],
+  "suites": ["test/index.html"],
   "plugins": {
     "local": {
       "disabled": true,

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,6 +5,7 @@
     "local": {
       "disabled": true,
       "browsers": [
+        "chrome",
         "firefox"
       ]
     },

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,7 +5,7 @@
     "local": {
       "disabled": true,
       "browsers": [
-        "chrome"
+        "firefox"
       ]
     },
     "sauce": {


### PR DESCRIPTION
- Decoupled the `closed` attribute from the view logic
- Added app state as the source of truth
- Added proper attribute change handling
- Improved handling of animations/transitions
- Added WCT test infra, use WCT for `util` tests and add tests for `mp-modal`