### PR TITLE
make empty svg-icon resilient to rendering before attributes have been set

### DIFF
--- a/lib/components/svg-icon/index.js
+++ b/lib/components/svg-icon/index.js
@@ -39,11 +39,13 @@ registerMPComponent('svg-icon', class extends WebComponent {
       this.innerHTML = '';
     } else {
       const icon = this.getAttribute('icon');
-      const markup = SVG_ICONS[icon];
-      if (!markup) {
-        throw new Error(`No svg-icon "${icon}" found.`);
+      if (icon) {
+        const markup = SVG_ICONS[icon];
+        if (!markup) {
+          throw new Error(`No svg-icon "${icon}" found.`);
+        }
+        this.innerHTML = markup;
       }
-      this.innerHTML = markup;
     }
   }
 });


### PR DESCRIPTION
looks like `attachedCallback()` can get called before `attributeChangedCallback`
registers the `empty` attr, so simply don't render anything in that case. the error doesn't kill anything (the component renders itself properly immediately afterwards when `empty` gets set) but it's a lot of monitoring noise.