### PR TITLE
Add 'bottom', 'left', 'right' placements for tooltip widget

### DIFF
--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -212,13 +212,19 @@
     h1 Spinners
     mp-spinner
 
-  .section
+  .section.tooltips
     h1 Tooltips
-    p.mp-font-paragraph
-      a
-        | Hover me
+
+    .tooltips-container
+      a.tooltip-container Default tooltip
         mp-tooltip This is my tooltip
 
+      a.tooltip-container Placement 'bottom' tooltip
+        mp-tooltip(attributes={'placement': 'bottom'}) This is my tooltip
+
+      a.tooltip-container Multi-line tooltip
+        mp-tooltip.multiline
+          span This is a long tooltip that spans multiple lines
 
   .section.widgets
     h1 Widgets

--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -216,15 +216,21 @@
     h1 Tooltips
 
     .tooltips-container
-      a.tooltip-container Default tooltip
-        mp-tooltip This is my tooltip
+      a.tooltip-container Default (placement 'top') tooltip
+        mp-tooltip Tooltip above the element
 
       a.tooltip-container Placement 'bottom' tooltip
-        mp-tooltip(attributes={'placement': 'bottom'}) This is my tooltip
+        mp-tooltip(attributes={'placement': 'bottom'}) Tooltip below the element
+
+      a.tooltip-container Placement 'left' tooltip
+        mp-tooltip(attributes={'placement': 'left'}) Tooltip on the left side of element
+
+      a.tooltip-container Placement 'right' tooltip
+        mp-tooltip(attributes={'placement': 'right'}) Tooltip on the right side of element
 
       a.tooltip-container Multi-line tooltip
         mp-tooltip.multiline
-          span This is a long tooltip that spans multiple lines
+          span This is a long tooltip with text that spans multiple lines
 
   .section.widgets
     h1 Widgets

--- a/examples/style-guide/index.styl
+++ b/examples/style-guide/index.styl
@@ -70,9 +70,9 @@
       align-items center
 
       .tooltip-container
-        margin: 5px 0;
+        margin 5px 0
         mp-tooltip.multiline span
-          max-width: 200px
+          max-width 200px
 
   &.menus
     .drop-menu-container

--- a/examples/style-guide/index.styl
+++ b/examples/style-guide/index.styl
@@ -2,9 +2,8 @@
 @import '../../build/stylesheets/mixins/common.styl'
 
 .section
-  margin-bottom 10px
-  padding-bottom 10px
   border-bottom 1px solid grey-100
+  padding 10px 20px
 
   .item-palette
     display flex
@@ -63,6 +62,17 @@
 
     .toggle-val
       margin-left 10px
+
+  &.tooltips
+    .tooltips-container
+      display flex
+      flex-direction column
+      align-items center
+
+      .tooltip-container
+        margin: 5px 0;
+        mp-tooltip.multiline span
+          max-width: 200px
 
   &.menus
     .drop-menu-container

--- a/lib/components/tooltip/index.jade
+++ b/lib/components/tooltip/index.jade
@@ -4,10 +4,10 @@
   onmousedown=$helpers.stopPropagation
 )
   .mp-tooltip-main(
-    class=placementClass
+    class={[`mp-tooltip-placement-${placement}`]: true}
     style={
-      'left': '#{leftOffset}px',
-      'top': '#{topOffset}px',
+      'left': `${leftOffset}px`,
+      'top': `${topOffset}px`,
     }
   )
     content

--- a/lib/components/tooltip/index.jade
+++ b/lib/components/tooltip/index.jade
@@ -1,3 +1,13 @@
-.mp-tooltip-wrapper.mp-tooltip-hidden
-  .mp-tooltip-main
+.mp-tooltip-wrapper(
+  class={'mp-tooltip-hidden': !isVisible}
+  onclick=$helpers.stopPropagation
+  onmousedown=$helpers.stopPropagation
+)
+  .mp-tooltip-main(
+    class=placementClass
+    style={
+      'left': `${leftOffset}px`,
+      'top': `${topOffset}px`,
+    }
+  )
     content

--- a/lib/components/tooltip/index.jade
+++ b/lib/components/tooltip/index.jade
@@ -6,8 +6,8 @@
   .mp-tooltip-main(
     class=placementClass
     style={
-      'left': `${leftOffset}px`,
-      'top': `${topOffset}px`,
+      'left': '#{leftOffset}px',
+      'top': '#{topOffset}px',
     }
   )
     content

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -31,8 +31,11 @@ registerMPElement(`mp-tooltip`, class extends Component {
 
     const placement = this.getAttribute(`placement`) || `top`;
     this.update({
-      placementClass: `mp-tooltip-placement-${placement}`,
       isVisible: true,
+      // Use a large negative offset so that the tooltip is off-screen until it's properly positioned.
+      leftOffset: -9999,
+      placementClass: `mp-tooltip-placement-${placement}`,
+      topOffset: -9999,
     });
 
     window.requestAnimationFrame(() => {

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -34,7 +34,7 @@ registerMPElement(`mp-tooltip`, class extends Component {
       isVisible: true,
       // Use a large negative offset so that the tooltip is off-screen until it's properly positioned.
       leftOffset: -9999,
-      placement: placement,
+      placement,
       topOffset: -9999,
     });
 

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -15,7 +15,7 @@ registerMPElement(`mp-tooltip`, class extends Component {
       defaultState: {
         isVisible: false,
         leftOffset: 0,
-        placementClass: ``,
+        placement: ``,
         topOffset: 0,
       },
       helpers: {
@@ -34,7 +34,7 @@ registerMPElement(`mp-tooltip`, class extends Component {
       isVisible: true,
       // Use a large negative offset so that the tooltip is off-screen until it's properly positioned.
       leftOffset: -9999,
-      placementClass: `mp-tooltip-placement-${placement}`,
+      placement: placement,
       topOffset: -9999,
     });
 

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -36,13 +36,25 @@ registerMPElement(`mp-tooltip`, class extends Component {
     });
 
     window.requestAnimationFrame(() => {
-      const leftOffset = this.parentNode.offsetLeft + (this.parentNode.offsetWidth / 2) - (tooltip.offsetWidth / 2);
+      // Since computation of top/left offsets depend on tooltip's height/width, these offsets must be computed
+      // after tooltip is visible, hence in requestAnimationFrame.
 
+      let leftOffset;
       let topOffset;
-      if (placement === `bottom`) {
-        topOffset = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8;
-      } else if (placement === `top`) {
-        topOffset = this.parentNode.offsetTop - tooltip.offsetHeight - 8;
+      if (placement === `top` || placement === `bottom`) {
+        leftOffset = this.parentNode.offsetLeft + (this.parentNode.offsetWidth - tooltip.offsetWidth) / 2;
+        if (placement === `top`) {
+          topOffset = this.parentNode.offsetTop - tooltip.offsetHeight - 8;
+        } else {
+          topOffset = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8;
+        }
+      } else if (placement === `left` || placement === `right`) {
+        topOffset = this.parentNode.offsetTop + (this.parentNode.offsetHeight - tooltip.offsetHeight) / 2;
+        if (placement === `left`) {
+          leftOffset = this.parentNode.offsetLeft - tooltip.offsetWidth - 8;
+        } else {
+          leftOffset = this.parentNode.offsetLeft + this.parentNode.offsetWidth + 8;
+        }
       }
 
       this.update({

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -12,44 +12,63 @@ registerMPElement(`mp-tooltip`, class extends Component {
       css,
       template,
       useShadowDom: true,
+      defaultState: {
+        isVisible: false,
+        leftOffset: 0,
+        placementClass: ``,
+        topOffset: 0,
+      },
+      helpers: {
+        stopPropagation: e => {
+          e.stopPropagation();
+        },
+      },
     };
+  }
+
+  show() {
+    const tooltip = this.el.querySelector(`.mp-tooltip-main`);
+
+    const placement = this.getAttribute(`placement`) || `top`;
+    this.update({
+      placementClass: `mp-tooltip-placement-${placement}`,
+      isVisible: true,
+    });
+
+    window.requestAnimationFrame(() => {
+      const leftOffset = this.parentNode.offsetLeft + (this.parentNode.offsetWidth / 2) - (tooltip.offsetWidth / 2);
+
+      let topOffset;
+      if (placement === `bottom`) {
+        topOffset = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8;
+      } else if (placement === `top`) {
+        topOffset = this.parentNode.offsetTop - tooltip.offsetHeight - 8;
+      }
+
+      this.update({
+        leftOffset,
+        topOffset,
+      });
+    });
+  }
+
+  hide() {
+    this.update({isVisible: false});
   }
 
   attachedCallback() {
     super.attachedCallback(...arguments);
-    const wrapper = this.el.querySelector(`.mp-tooltip-wrapper`);
-    const tooltip = this.el.querySelector(`.mp-tooltip-main`);
-    this.show = () => {
-      wrapper.classList.remove(`mp-tooltip-hidden`);
 
-      const leftPos = this.parentNode.offsetLeft + (this.parentNode.offsetWidth / 2) - (tooltip.offsetWidth / 2) + `px`;
-      tooltip.style.left = leftPos;
+    this.show = this.show.bind(this);
+    this.hide = this.hide.bind(this);
 
-      const placement = this.getAttribute(`placement`) || `top`;
-      tooltip.classList.add(`mp-tooltip-placement-${placement}`);
-      if (placement === `bottom`) {
-        tooltip.style.top = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8 + `px`;
-      } else if (placement === `top`) {
-        tooltip.style.top = this.parentNode.offsetTop - tooltip.offsetHeight - 8 + `px`;
-      }
-    };
-    this.hide = () => {
-      wrapper.classList.add(`mp-tooltip-hidden`);
-    };
-    this.stopPropagation = e => {
-      e.stopPropagation();
-    };
     this.parentNode.addEventListener(`mouseover`, this.show);
     this.parentNode.addEventListener(`mouseleave`, this.hide);
-    this.el.addEventListener(`click`, this.stopPropagation);
-    this.el.addEventListener(`mousedown`, this.stopPropagation);
   }
 
   detachedCallback() {
     super.detachedCallback(...arguments);
     this.parentNode.removeEventListener(`mouseover`, this.show);
-    this.parentNode.removeEventListener(`mouseover`, this.hide);
-    this.el.removeEventListener(`click`, this.stopPropagation);
-    this.el.removeEventListener(`mousedown`, this.stopPropagation);
+    this.parentNode.removeEventListener(`mouseleave`, this.hide);
   }
 });

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -21,10 +21,17 @@ registerMPElement(`mp-tooltip`, class extends Component {
     const tooltip = this.el.querySelector(`.mp-tooltip-main`);
     this.show = () => {
       wrapper.classList.remove(`mp-tooltip-hidden`);
+
       const leftPos = this.parentNode.offsetLeft + (this.parentNode.offsetWidth / 2) - (tooltip.offsetWidth / 2) + `px`;
-      const topPos = this.parentNode.offsetTop - tooltip.offsetHeight - 8 + `px`;
       tooltip.style.left = leftPos;
-      tooltip.style.top = topPos;
+
+      const placement = this.getAttribute(`placement`) || `top`;
+      tooltip.classList.add(`mp-tooltip-placement-${placement}`);
+      if (placement === `bottom`) {
+        tooltip.style.top = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8 + `px`;
+      } else if (placement === `top`) {
+        tooltip.style.top = this.parentNode.offsetTop - tooltip.offsetHeight - 8 + `px`;
+      }
     };
     this.hide = () => {
       wrapper.classList.add(`mp-tooltip-hidden`);

--- a/lib/components/tooltip/index.styl
+++ b/lib/components/tooltip/index.styl
@@ -25,22 +25,35 @@
       padding 10px 18px
       pointer-events auto
       position absolute
-      text-align center
       text-transform initial
 
       &::after
         border 5px solid transparent
         content ''
         height 0
-        left 50%
-        margin-left -5px
         position absolute
         width 0
 
       &.placement-top::after
         border-top-color grey-900
+        left 50%
+        margin-left -5px
         top 100%
 
       &.placement-bottom::after
         border-bottom-color grey-900
+        left 50%
+        margin-left -5px
         bottom 100%
+
+      &.placement-left::after
+        border-left-color grey-900
+        left 100%
+        margin-top -5px
+        top 50%
+
+      &.placement-right::after
+        border-right-color grey-900
+        margin-top -5px
+        right 100%
+        top 50%

--- a/lib/components/tooltip/index.styl
+++ b/lib/components/tooltip/index.styl
@@ -22,19 +22,25 @@
       font-size-default()
       font-weight bold
       justify-content center
-      line-height 9px
-      padding 13px 18px
+      padding 10px 18px
       pointer-events auto
       position absolute
+      text-align center
       text-transform initial
 
       &::after
         border 5px solid transparent
-        border-top-color grey-900
         content ''
         height 0
         left 50%
         margin-left -5px
         position absolute
-        top 100%
         width 0
+
+      &.placement-top::after
+        border-top-color grey-900
+        top 100%
+
+      &.placement-bottom::after
+        border-bottom-color grey-900
+        bottom 100%


### PR DESCRIPTION
- Support placement of tooltip widget on all sides
- Add examples of various placements of tooltip
- Add example of multi-line tooltip

![image](https://cloud.githubusercontent.com/assets/198538/21710660/014778ca-d39f-11e6-813e-5103b240e4f8.png)

![image](https://cloud.githubusercontent.com/assets/198538/21710670/0af8e7fa-d39f-11e6-86bc-005bfaee7c36.png)

![image](https://cloud.githubusercontent.com/assets/198538/21710770/a4343f00-d39f-11e6-9358-0d52e8ebd41d.png)

![image](https://cloud.githubusercontent.com/assets/198538/21710775/af36a834-d39f-11e6-870e-740310bded52.png)

![image](https://cloud.githubusercontent.com/assets/198538/21710781/b5318bbe-d39f-11e6-98f0-6f8d6b645224.png)
