### PR TITLE
Fix some problems with the tooltip

### DIFF
--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -232,6 +232,10 @@
         mp-tooltip.multiline
           span This is a long tooltip with text that spans multiple lines
 
+      a.tooltip-container.position-relative Tooltip with non-statically positioned parent element
+        mp-tooltip
+          span A tooltip
+
   .section.widgets
     h1 Widgets
     p

--- a/examples/style-guide/index.styl
+++ b/examples/style-guide/index.styl
@@ -71,6 +71,12 @@
 
       .tooltip-container
         margin 5px 0
+
+        &.position-relative
+          position relative
+          left 100px
+          top 10px
+
         mp-tooltip.multiline span
           max-width 200px
 

--- a/lib/components/tooltip/index.jade
+++ b/lib/components/tooltip/index.jade
@@ -1,5 +1,8 @@
 .mp-tooltip-wrapper(
-  class={'mp-tooltip-hidden': !isVisible}
+  class={
+    'mp-tooltip-hidden': visibility === 'hidden',
+    'mp-tooltip-transitioning': visibility === 'transitioning',
+  }
   onclick=$helpers.stopPropagation
   onmousedown=$helpers.stopPropagation
 )

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -6,6 +6,10 @@ import template from './index.jade';
 
 import css from './index.styl';
 
+const VISIBILITY_HIDDEN = `hidden`;
+const VISIBILITY_TRANSITIONING = `transitioning`;
+const VISIBILITY_VISIBLE = `visible`;
+
 registerMPElement(`mp-tooltip`, class extends Component {
   get config() {
     return {
@@ -13,7 +17,7 @@ registerMPElement(`mp-tooltip`, class extends Component {
       template,
       useShadowDom: true,
       defaultState: {
-        isVisible: false,
+        visibility: VISIBILITY_HIDDEN,
         leftOffset: 0,
         placement: ``,
         topOffset: 0,
@@ -31,11 +35,8 @@ registerMPElement(`mp-tooltip`, class extends Component {
 
     const placement = this.getAttribute(`placement`) || `top`;
     this.update({
-      isVisible: true,
-      // Use a large negative offset so that the tooltip is off-screen until it's properly positioned.
-      leftOffset: -9999,
+      visibility: VISIBILITY_TRANSITIONING,
       placement,
-      topOffset: -9999,
     });
 
     window.requestAnimationFrame(() => {
@@ -77,12 +78,13 @@ registerMPElement(`mp-tooltip`, class extends Component {
       this.update({
         leftOffset,
         topOffset,
+        visibility: VISIBILITY_VISIBLE,
       });
     });
   }
 
   hide() {
-    this.update({isVisible: false});
+    this.update({visibility: VISIBILITY_HIDDEN});
   }
 
   attachedCallback() {

--- a/lib/components/tooltip/index.js
+++ b/lib/components/tooltip/index.js
@@ -42,21 +42,35 @@ registerMPElement(`mp-tooltip`, class extends Component {
       // Since computation of top/left offsets depend on tooltip's height/width, these offsets must be computed
       // after tooltip is visible, hence in requestAnimationFrame.
 
+      let parentOffsetLeft;
+      let parentOffsetTop;
+      const parentPosition = window.getComputedStyle(this.parentNode).getPropertyValue(`position`);
+      // The tooltip has position absolute, which means it will be positioned relative to the nearest ancestor with
+      // non-static position. Different handling is needed depending on whether the direct parent of the tooltip
+      // has non-static positioning.
+      if (parentPosition === `static`) {
+        parentOffsetLeft = this.parentNode.offsetLeft;
+        parentOffsetTop = this.parentNode.offsetTop;
+      } else {
+        parentOffsetLeft = 0;
+        parentOffsetTop = 0;
+      }
+
       let leftOffset;
       let topOffset;
       if (placement === `top` || placement === `bottom`) {
-        leftOffset = this.parentNode.offsetLeft + (this.parentNode.offsetWidth - tooltip.offsetWidth) / 2;
+        leftOffset = parentOffsetLeft + (this.parentNode.offsetWidth - tooltip.offsetWidth) / 2;
         if (placement === `top`) {
-          topOffset = this.parentNode.offsetTop - tooltip.offsetHeight - 8;
+          topOffset = parentOffsetTop - tooltip.offsetHeight - 8;
         } else {
-          topOffset = this.parentNode.offsetTop + this.parentNode.offsetHeight + 8;
+          topOffset = parentOffsetTop + this.parentNode.offsetHeight + 8;
         }
       } else if (placement === `left` || placement === `right`) {
-        topOffset = this.parentNode.offsetTop + (this.parentNode.offsetHeight - tooltip.offsetHeight) / 2;
+        topOffset = parentOffsetTop + (this.parentNode.offsetHeight - tooltip.offsetHeight) / 2;
         if (placement === `left`) {
-          leftOffset = this.parentNode.offsetLeft - tooltip.offsetWidth - 8;
+          leftOffset = parentOffsetLeft - tooltip.offsetWidth - 8;
         } else {
-          leftOffset = this.parentNode.offsetLeft + this.parentNode.offsetWidth + 8;
+          leftOffset = parentOffsetLeft + this.parentNode.offsetWidth + 8;
         }
       }
 
@@ -77,13 +91,13 @@ registerMPElement(`mp-tooltip`, class extends Component {
     this.show = this.show.bind(this);
     this.hide = this.hide.bind(this);
 
-    this.parentNode.addEventListener(`mouseover`, this.show);
+    this.parentNode.addEventListener(`mouseenter`, this.show);
     this.parentNode.addEventListener(`mouseleave`, this.hide);
   }
 
   detachedCallback() {
     super.detachedCallback(...arguments);
-    this.parentNode.removeEventListener(`mouseover`, this.show);
+    this.parentNode.removeEventListener(`mouseenter`, this.show);
     this.parentNode.removeEventListener(`mouseleave`, this.hide);
   }
 });

--- a/lib/components/tooltip/index.styl
+++ b/lib/components/tooltip/index.styl
@@ -10,6 +10,15 @@
       .main
         display none
 
+    &.transitioning
+      pointer-events none
+      .main
+        // An alternative that was tried was positioning the tooltip off the page with left:-9999, top: -9999.
+        // However, this in some cases the width of the tooltip is different when it's off the page vs. when it's
+        // finally positioned on the page. This screws up the tooltip position computation which depends on the
+        // final width of the tooltip. Using visibility:hidden doesn't suffer from this problem.
+        visibility hidden
+
     .main
       align-items center
       background-color grey-900


### PR DESCRIPTION
1. Use mouseenter instead of mouseover since mouseover is fired when
moving into a child element.
2. Handle case when parent element has non-static position.