### PR TITLE
upgrade panel for new ID behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "mixpanel-browser": "2.9.16",
-    "panel": "0.10.0-rc4",
+    "panel": "0.10.0-rc5",
     "rollbar-browser": "1.9.1",
     "webcomponent": "^0.1.2"
   },


### PR DESCRIPTION
Running panel code from two separate copies (as we sometimes do
with mixpanel-common components + app code) could cause ID collisions
because it was a simple auto-incrementing counter scoped to the
module. This version uses collision-resistent IDs and also turns
them into internal component props rather than HTML attrs.