### PR TITLE
Add pinned tags that stay on top of list & default tags that cannot be removed

### DIFF
--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -289,6 +289,7 @@
           .subtext Viewed report by type
         mp-tag-selector(
           attrs={
+            'pinned-tags': JSON.stringify(tagSelectorData.pinnedTags),
             'selected-tags': JSON.stringify(tagSelectorData.selectedTags),
             'all-tags': JSON.stringify(tagSelectorData.allTags),
             'load-state': tagSelectorLoadState,

--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -290,6 +290,7 @@
         mp-tag-selector(
           attrs={
             'pinned-tags': JSON.stringify(tagSelectorData.pinnedTags),
+            'default-tags': JSON.stringify(tagSelectorData.defaultTags),
             'selected-tags': JSON.stringify(tagSelectorData.selectedTags),
             'all-tags': JSON.stringify(tagSelectorData.allTags),
             'load-state': tagSelectorLoadState,

--- a/examples/style-guide/index.js
+++ b/examples/style-guide/index.js
@@ -12,11 +12,11 @@ import bookmarks from './bookmark-data.json';
 import template from './index.jade';
 import './index.styl';
 
-document.registerElement('style-guide', class extends Component {
+document.registerElement(`style-guide`, class extends Component {
   get config() {
     return {
       defaultState: {
-        blueToggleValue: 'option1',
+        blueToggleValue: `option1`,
         bookmarks,
         COLORS,
         SVG_ICONS,
@@ -32,11 +32,12 @@ document.registerElement('style-guide', class extends Component {
         },
         savingBookmark: false,
         selectedBookmarkId: null,
-        tagSelectorLoadState: 'idle',
+        tagSelectorLoadState: `idle`,
         tagSelectorData: {
-          selectedTags: new Set(["my tag", "another tag"]),
-          allTags: new Set(["my tag", "another tag", "our tag", "his tag"]),
-        }
+          pinnedTags: new Set([`pinned tag`]),
+          selectedTags: new Set([`my tag`, `another tag`]),
+          allTags: new Set([`my tag`, `another tag`, `pinned tag`, `our tag`, `his tag`]),
+        },
       },
       helpers: {
         blueToggleChanged: ev => this.update({blueToggleValue: ev.detail.selected}),
@@ -49,17 +50,17 @@ document.registerElement('style-guide', class extends Component {
           this.update();
         },
         handleModalChange: (key, state) => {
-          this.state.open[key] = state === 'open';
+          this.state.open[key] = state === `open`;
           this.update();
         },
         handleNamerChange: e => {
-          console.log('mp-input-group value changed to: ', e.target.value);
+          console.log(`mp-input-group value changed to: `, e.target.value);
         },
         handleNamerSubmit: () => {
           this.update({inputGroupSaving: true});
           setTimeout(() => {
             this.update({inputGroupSaving: false});
-            alert('Saved!');
+            alert(`Saved!`);
           }, 2000);
         },
         toggleMenu: () => {
@@ -68,21 +69,21 @@ document.registerElement('style-guide', class extends Component {
         },
         handleBookmarksMenuSubmit: e => {
           switch (e.detail.action) {
-            case 'select':
-              console.log('Selected:', e.detail.value.id);
+            case `select`:
+              console.log(`Selected:`, e.detail.value.id);
               break;
-            case 'delete':
+            case `delete`:
               this.update({bookmarks: this.state.bookmarks.filter(b => b.id !== e.detail.bookmarkId)});
               break;
-            case 'create':
+            case `create`:
               this.update({savingBookmark: true});
               setTimeout(() => {
-                console.log('Created:', e.detail.name);
+                console.log(`Created:`, e.detail.name);
                 const newBookmark = {
                   id: (new Date()).getTime(),
                   user_id: 1,
                   name: e.detail.name,
-                  user: 'John D.',
+                  user: `John D.`,
                 };
                 this.state.bookmarks.push(newBookmark);
                 this.update({savingBookmark: false, selectedBookmarkId: newBookmark.id});
@@ -100,7 +101,7 @@ document.registerElement('style-guide', class extends Component {
           this.update();
         },
         handleTagSelectorDropMenuChange: e => {
-          this.state.open.tagSelector = e.detail.state !== 'closed';
+          this.state.open.tagSelector = e.detail.state !== `closed`;
           this.update();
         },
         handleTagSelectorChange: e => {
@@ -108,18 +109,18 @@ document.registerElement('style-guide', class extends Component {
           // handle whatever business logic we need to deal with when
           // adding or removing a tag
           const tagName = e.detail.tagName;
-          if (e.detail.action === 'addTag') {
+          if (e.detail.action === `addTag`) {
             this.state.tagSelectorData.selectedTags.add(tagName);
             this.state.tagSelectorData.allTags.add(tagName);
-          } else if (e.detail.action === 'removeTag') {
+          } else if (e.detail.action === `removeTag`) {
             this.state.tagSelectorData.selectedTags.delete(tagName);
           }
           // normally we'd persist to server and this timeout represents that
           // async call
           clearTimeout(this.loadingTagTimeout);
-          this.update({tagSelectorLoadState: 'loading_tag'});
+          this.update({tagSelectorLoadState: `loading_tag`});
           this.loadingTagTimeout = setTimeout(() => {
-            this.update({tagSelectorLoadState: 'loaded_tag'});
+            this.update({tagSelectorLoadState: `loaded_tag`});
           }, 700);
         },
         handleTagSelectorSubmit: e => {

--- a/examples/style-guide/index.js
+++ b/examples/style-guide/index.js
@@ -35,8 +35,9 @@ document.registerElement(`style-guide`, class extends Component {
         tagSelectorLoadState: `idle`,
         tagSelectorData: {
           pinnedTags: new Set([`pinned tag`]),
-          selectedTags: new Set([`my tag`, `another tag`]),
-          allTags: new Set([`my tag`, `another tag`, `pinned tag`, `our tag`, `his tag`]),
+          defaultTags: new Set([`default tag`]),
+          selectedTags: new Set([`my tag`, `another tag`, `default tag`]),
+          allTags: new Set([`my tag`, `another tag`, `pinned tag`, `default tag`, `our tag`, `his tag`]),
         },
       },
       helpers: {

--- a/lib/util/function.js
+++ b/lib/util/function.js
@@ -14,13 +14,17 @@ export function mapArguments(fn, argMap) {
 }
 
 /**
- * compose two orderings lexically to create a single combined ordering.
+ * Compose an arbitrary number of orderings lexically to create a single combined ordering.
  */
-export function lexicalCompose(fn1, fn2) {
+export function lexicalCompose(...args) {
   return (a, b) => {
-    let cmp = fn1(a, b);
-    return cmp === 0 ? fn2(a, b) : cmp;
+    const order = idx => {
+      const cmp = args[idx](a, b);      
+      return cmp === 0 && idx !== args.length - 1 ? order(++idx) : cmp;
+    };
+    return order(0);
   };
 }
+
 
 export const defaultOrdering = leqToNumericOrdering((a, b) => a <= b);

--- a/lib/util/function.js
+++ b/lib/util/function.js
@@ -17,7 +17,7 @@ export function mapArguments(fn, argMap) {
  * Compose an arbitrary number of orderings lexically to create a single combined ordering.
  */
 export function lexicalCompose(...args) {
-  return (a, b) => args.reduce((acc, curr) => acc === 0 ? curr(a, b) : acc);
+  return (a, b) => args.reduce((acc, curr) => acc === 0 ? curr(a, b) : acc, 0);
 }
 
 

--- a/lib/util/function.js
+++ b/lib/util/function.js
@@ -17,13 +17,7 @@ export function mapArguments(fn, argMap) {
  * Compose an arbitrary number of orderings lexically to create a single combined ordering.
  */
 export function lexicalCompose(...args) {
-  return (a, b) => {
-    const order = idx => {
-      const cmp = args[idx](a, b);      
-      return cmp === 0 && idx !== args.length - 1 ? order(++idx) : cmp;
-    };
-    return order(0);
-  };
+  return (a, b) => args.reduce((acc, curr) => acc === 0 ? curr(a, b) : acc);
 }
 
 

--- a/lib/widgets/tag-selector/index.jade
+++ b/lib/widgets/tag-selector/index.jade
@@ -18,7 +18,7 @@
         if !$component.isAttributeEnabled('read-only')
           - const tags = [...selectedTags];
           for tag in tags
-            - const attrs = {'tag-name': tag, 'removable': true}
+            - const attrs = {'tag-name': tag, 'removable': !defaultTags.has(tag)}
             if tag.toLowerCase() === 'my reports'
               - attrs.icon = 'lock-locked'
             mp-tag(

--- a/lib/widgets/tag-selector/index.js
+++ b/lib/widgets/tag-selector/index.js
@@ -81,6 +81,7 @@ registerMPElement(`mp-tag-selector`, class extends Component {
     super.attachedCallback(...arguments);
     this.update({
       pinnedTags: new Set(this.getJSONAttribute(`pinned-tags`)),
+      defaultTags: new Set(this.getJSONAttribute(`default-tags`)),
       selectedTags: new Set(this.getJSONAttribute(`selected-tags`)),
       allTags: new Set(this.getJSONAttribute(`all-tags`)),
       loadState: this.getAttribute(`load-state`),

--- a/lib/widgets/tag-selector/index.js
+++ b/lib/widgets/tag-selector/index.js
@@ -80,6 +80,7 @@ registerMPElement(`mp-tag-selector`, class extends Component {
   attachedCallback() {
     super.attachedCallback(...arguments);
     this.update({
+      pinnedTags: new Set(this.getJSONAttribute(`pinned-tags`)),
       selectedTags: new Set(this.getJSONAttribute(`selected-tags`)),
       allTags: new Set(this.getJSONAttribute(`all-tags`)),
       loadState: this.getAttribute(`load-state`),
@@ -118,17 +119,22 @@ registerMPElement(`mp-tag-selector`, class extends Component {
     const search = this.state.inputText.trim().toLowerCase();
     const matchingTags = [...this.state.allTags]
       .map(tag => tag.toLowerCase())
+      .filter(tag => !search.length || !this.state.pinnedTags.has(tag))
       .filter(tag => !this.state.selectedTags.has(tag) && stringFilterMatches(tag, search))
       .sort(
         lexicalCompose(
-          // first sort by whether the string matches the search string exactly
-          mapArguments(defaultOrdering, a => a.toLowerCase() === search ? 0 : 1),
-          // then sort alphabetically
-          mapArguments(defaultOrdering, a => a.toLowerCase())));
+          // put the pinned tags on top
+          mapArguments(defaultOrdering, a => this.state.pinnedTags.has(a) ? 0 : 1),     
+          // then sort by whether the string matches the search string exactly
+          mapArguments(defaultOrdering, a => a === search ? 0 : 1),
+          // finally, sort alphabetically
+          defaultOrdering)
+      );
     let activeTagIndex = matchingTags.indexOf(search);
     if(activeTagIndex === -1 && matchingTags.length) {
       activeTagIndex = 0;
     }
+
     this.update({matchingTags, activeTagIndex});
   }
 

--- a/lib/widgets/tag-selector/index.js
+++ b/lib/widgets/tag-selector/index.js
@@ -20,6 +20,10 @@ registerMPElement(`mp-tag-selector`, class extends Component {
     return {
       defaultState: {
         activeTagIndex: -1,
+        // default tags cannot be removed by the user
+        defaultTags: new Set(),
+        // pinned tags are placed at the top of the list, but disappear once the user starts typing
+        pinnedTags: new Set(),
         selectedTags: new Set(),
         allTags: new Set(),
         matchingTags: [],
@@ -124,10 +128,10 @@ registerMPElement(`mp-tag-selector`, class extends Component {
       .filter(tag => !this.state.selectedTags.has(tag) && stringFilterMatches(tag, search))
       .sort(
         lexicalCompose(
-          // put the pinned tags on top
-          mapArguments(defaultOrdering, a => this.state.pinnedTags.has(a) ? 0 : 1),     
-          // then sort by whether the string matches the search string exactly
+          // sort by whether the string matches the search string exactly
           mapArguments(defaultOrdering, a => a === search ? 0 : 1),
+          // then put the pinned tags on top
+          mapArguments(defaultOrdering, a => this.state.pinnedTags.has(a) ? 0 : 1),
           // finally, sort alphabetically
           defaultOrdering)
       );


### PR DESCRIPTION
 The use case for this is the “All Reports” tag in dashboards. Pinned tags stay at the top of the list, but then go away once the user starts typing. Default tags would include our `segmentation` tag -- it can be seen but not removed by the user. My two main concerns here are that this might be a bit specific for a common component, and that the uber-functional style of this code might be a bit esoteric. Would love to hear thoughts from folks.