### PR TITLE
mp-toggle updates

### DIFF
--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -196,8 +196,8 @@
   .section.toggles
     h1 Toggles
     p One element out of a set of two or more is always selected.
-    mp-toggle.mp-toggle-blue.inline-toggle(
-      attrs={selected: blueToggleValue}
+    mp-toggle.inline-toggle(
+      attrs={blue: true, selected: blueToggleValue}
       on={change: $helpers.blueToggleChanged}
     )
       mp-toggle-option(attrs={value: 'option1'}) Longer Option 1
@@ -209,9 +209,15 @@
       mp-toggle-option(attrs={value: 'option2'}) Short
       mp-toggle-option(attrs={value: 'option3'}) Medium text here
 
-    mp-toggle.full-width-toggle.large-toggle(attrs={selected: 'option2'})
+    mp-toggle.full-width-toggle(attrs={large: true, selected: 'option2'})
       mp-toggle-option(attrs={value: 'option1'}) Longer Option 1
       mp-toggle-option(attrs={value: 'option2'}) Longer Option 2
+
+    h4 Square toggle
+    mp-toggle.inline-toggle(attrs={square: true, selected: 'all'})
+      mp-toggle-option(attrs={value: 'all'}) All
+      mp-toggle-option(attrs={value: 'events'}) Events
+      mp-toggle-option(attrs={value: 'people'}) People
 
   .section
     h1 Spinners

--- a/examples/style-guide/index.jade
+++ b/examples/style-guide/index.jade
@@ -198,7 +198,7 @@
     p One element out of a set of two or more is always selected.
     mp-toggle.inline-toggle(
       attrs={blue: true, selected: blueToggleValue}
-      on={change: $helpers.blueToggleChanged}
+      on={select: $helpers.blueToggleChanged}
     )
       mp-toggle-option(attrs={value: 'option1'}) Longer Option 1
       mp-toggle-option(attrs={value: 'option2'}) Opt2

--- a/lib/components/toggle/index.jade
+++ b/lib/components/toggle/index.jade
@@ -1,4 +1,8 @@
-.mp-toggle(class=$helpers.extendComponentClasses())
+.mp-toggle(class={
+  'toggle-blue': $component.isAttributeEnabled(`blue`),
+  'toggle-large': $component.isAttributeEnabled(`large`),
+  'toggle-square': $component.isAttributeEnabled(`square`),
+})
   for toggleOption in $helpers.toggleOptions()
     .mp-toggle-option(
       class={'mp-toggle-selected': toggleOption.value === $component.value}

--- a/lib/components/toggle/index.js
+++ b/lib/components/toggle/index.js
@@ -29,6 +29,9 @@ registerMPElement(`mp-toggle`, class extends Component {
   attributeChangedCallback(attr, oldVal, newVal) {
     super.attributeChangedCallback(...arguments);
     if (attr === `selected`) {
+      this.dispatchEvent(new CustomEvent(`select`, {detail: {selected: newVal}}));
+
+      // TODO deprecated: switch consumers to 'select' event
       this.dispatchEvent(new CustomEvent(`change`, {detail: {selected: newVal}}));
     }
   }

--- a/lib/components/toggle/index.js
+++ b/lib/components/toggle/index.js
@@ -1,6 +1,5 @@
 import { Component } from 'panel';
 
-import { extendComponentClasses } from '../../util/dom';
 import { registerMPElement } from  '../../util/register-element.js';
 
 import css from './index.styl';
@@ -14,7 +13,6 @@ registerMPElement(`mp-toggle`, class extends Component {
       useShadowDom: true,
 
       helpers: {
-        extendComponentClasses: extendComponentClasses.bind(this),
         selectOption: value => this.value = value,
         toggleOptions: () => Array.from(this.children)
           .filter(el => el.tagName.toLowerCase() === `mp-toggle-option`)

--- a/lib/components/toggle/index.styl
+++ b/lib/components/toggle/index.styl
@@ -53,3 +53,8 @@
 
   &.toggle-large
     height 40px
+
+  &.toggle-square
+    border-radius 4px
+    .mp-toggle-option
+      border-radius 3px

--- a/lib/components/toggle/index.styl
+++ b/lib/components/toggle/index.styl
@@ -30,6 +30,7 @@
     &.mp-toggle-selected
       background-color white
       box-shadow 0 1px 0 0 (rgba(0, 0, 0, 0.05))
+      color grey-900
 
     &:not(.mp-toggle-selected)
       cursor pointer

--- a/lib/components/toggle/index.styl
+++ b/lib/components/toggle/index.styl
@@ -36,7 +36,7 @@
       &:hover
         color blue-300
 
-  &.mp-toggle-blue
+  &.toggle-blue
     background-color blue-700
     box-shadow inset 0 1px 0 0 blue-900
 
@@ -51,6 +51,5 @@
       &:not(.mp-toggle-selected):hover
         color white
 
-.large-toggle
+  &.toggle-large
     height 40px
-


### PR DESCRIPTION
- choose styles via attrs instead of proxying CSS classes
- added super square mode

![screen shot 2017-01-24 at 4 20 38 pm](https://cloud.githubusercontent.com/assets/855881/22272775/138f6f4a-e251-11e6-98b8-285088fe07ce.png)
