### PR TITLE
Smart sorting

### DIFF
--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -1,3 +1,5 @@
+import { parseDate } from '../../lib/util/date';
+
 export function immutableSplice(array, ...args) {
   let copy = array.slice(0);
   copy.splice(...args);
@@ -36,26 +38,47 @@ export function insertAtIndex(array, index, value) {
 /**
  * Sort array without mutating original
  * @param {Array} arr - array to sort
- * @param {Object} options - sorting configuration
- * @param {string} [options.order='asc'] - sort order ('asc' or 'desc')
- * @param {function} [options.transform] - transforms each element for comparison
- * when sorting
+ * @param {string} [order='asc'] - sort order ('asc' or 'desc')
+ * @param {function} [transform=null] - transforms each element before comparison
+ * @param {function} [lowercase=false] - converts strings to lowercase before comparison
+ * @param {function} [orderNumDateAlpha=false] - converts numeric and date strings to integers before comparison
+ * @param {Object} [parseDateConfig={}] - config used for parsing dates when orderNumDateAlpha is true
  * @example
  * sorted(['XX', 'A', 'g'], {transform: s => s.toLowerCase()});
  * // ['A', 'g', 'XX']
  */
-export function sorted(arr, options={}) {
-  options.order = options.order || `asc`;
+export function sorted(arr, {order=`asc`, transform=null, lowercase=false, orderNumDateAlpha=false, parseDateConfig={}}={}) {
   return arr.slice().sort((a, b) => {
-    if (options.transform) {
-      a = options.transform(a);
-      b = options.transform(b);
+    if (transform) {
+      a = transform(a);
+      b = transform(b);
     }
+
+    if (lowercase) {
+      a = a.toLowerCase ? a.toLowerCase() : a;
+      b = b.toLowerCase ? b.toLowerCase() : b;
+    }
+
+    if (orderNumDateAlpha) {
+      const aNumber = Number(a.replace ? a.replace(`,`, ``) : a);
+      const bNumber = Number(b.replace ? b.replace(`,`, ``) : b);
+
+      if (!isNaN(aNumber) && !isNaN(bNumber)) {
+        a = aNumber;
+        b = bNumber;
+      } else {
+        const aDate = parseDate(a, parseDateConfig);
+        const bDate = parseDate(b, parseDateConfig);
+
+        if (aDate && bDate) {
+          a = aDate.getTime();
+          b = bDate.getTime();
+        }
+      }
+    }
+
     let cmp = a > b ? 1 : a < b ? -1 : 0;
-    if (options.order === `desc`) {
-      cmp *= -1;
-    }
-    return cmp;
+    return order === `desc` ? -1 * cmp : cmp;
   });
 }
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -7,12 +7,23 @@ import {
   mapArguments,
 } from './function';
 
+/**
+ * Perform a "splice" operation and return a new array without mutating the original
+ * @param {Array} array - the original array to splice
+ * @returns {Array} - a new array spliced from the original
+ */
 export function immutableSplice(array, ...args) {
-  let copy = array.slice(0);
-  copy.splice(...args);
-  return copy;
+  array = array.slice();
+  array.splice(...args);
+  return array;
 }
 
+/**
+ * Remove an item by index and return the resulting array without mutating the original
+ * @param {Array} array - the original array to remove an item from
+ * @param {number} index - the index of the item to remove
+ * @returns {Array} - a new array that is a copy of the original with an item removed
+ */
 export function removeByIndex(array, index) {
   if (index >= array.length || index < -array.length) {
     throw `IndexError: array index out of range`;
@@ -20,6 +31,12 @@ export function removeByIndex(array, index) {
   return immutableSplice(array, index, 1);
 }
 
+/**
+ * Remove an item by value and return the resulting array without mutating the original
+ * @param {Array} array - the original array to remove an item from
+ * @param {*} value - the value to remove
+ * @returns {Array} - a new array that is a copy of the original with an item removed
+ */
 export function removeByValue(array, value) {
   let index = array.indexOf(value);
   if (index === -1) {
@@ -28,6 +45,13 @@ export function removeByValue(array, value) {
   return removeByIndex(array, index);
 }
 
+/**
+ * Replace an item by index and return the resulting array without mutating the original
+ * @param {Array} array - the original array to replace an item from
+ * @param {number} index - the index of the item to replace
+ * @param {*} value - the value to replace the item with
+ * @returns {Array} - a new array that is a copy of the original with an item replaced
+ */
 export function replaceByIndex(array, index, value) {
   if (index >= array.length || index < -array.length) {
     throw `IndexError: array index out of range`;
@@ -35,6 +59,13 @@ export function replaceByIndex(array, index, value) {
   return immutableSplice(array, index, 1, value);
 }
 
+/**
+ * Insert an item at an index and return the resulting array without mutating the original
+ * @param {Array} array - the original array to insert an item into
+ * @param {number} index - the index to insert the new item at
+ * @param {*} value - the value of the new item
+ * @returns {Array} - a new array that is a copy of the original with the value inserted
+ */
 export function insertAtIndex(array, index, value) {
   if (index > array.length || index < -array.length) {
     throw `IndexError: array index out of range`;
@@ -49,10 +80,32 @@ const SORT_ORDERING = {
   desc: lexicalCompose(NULL_ORDERING, (a, b) => defaultOrdering(b, a)),
 };
 
+/**
+ * Construct a sort comparator function that orders items by numeric value, comparing them via a <= operation.
+ * null items are placed last in the sorted order.
+ * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
+ * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
+ * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
+ * @example
+ * <<< [1, 2, 3, 4, 5].sort(baseComparator({order: `desc`, transform: n => n % 2}));
+ * >>> [2, 4, 1, 3, 5] // sorted by even numbers followed by odd numbers
+ */
 export function baseComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], transform);
 }
 
+/**
+ * Construct a sort comparator function that orders date strings by parsed date value, converting them to integer timestamps and
+ * then comparing via a <= operation. Invalid date strings are placed last in the sorted order.
+ * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
+ * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
+ * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
+ * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
+ * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
+ * @example
+ * <<< [`12~1`, `blarg`, `12~2`].sort(baseComparator({order: `desc`, transform: dateString => dateString.replace(`~`, ` `)}));
+ * >>> [`12~2`, `12~1`, `blarg`] // sorted by parseable date value
+ */
 export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
@@ -61,6 +114,16 @@ export function dateStringComparator({order=`asc`, transform=identity, dateRegex
   });
 }
 
+/**
+ * Construct a sort comparator function that orders numeric strings by parsed numeric value, converting them to Numbers and
+ * then comparing via a <= operation. Invalid numeric strings are placed last in the sorted order.
+ * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
+ * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
+ * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
+ * @example
+ * <<< [`n:-9,000`, `n:blarg`, `n:42`].sort(baseComparator({order: `desc`, transform: numericString => numericString.split(:)[1]}));
+ * >>> [`n:42`, `n:-9,000`, `n:blarg`] // sorted by parseable numeric value
+ */
 export function numericComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
@@ -69,6 +132,17 @@ export function numericComparator({order=`asc`, transform=identity}={}) {
   });
 }
 
+/**
+ * Construct a sort comparator function that orders strings by parsed date, numeric, or alphabetic value.
+ * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
+ * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
+ * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
+ * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
+ * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
+ * @example
+ * <<< [`12/1`, `blarg`, `-9,000`, `12/2`, `42`].sort(baseComparator({order: `desc`}));
+ * >>> [`42`, `-9,000`, `12/2`, `12/1`, `blarg`]
+ */
 export function numDateAlphaComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
   return lexicalCompose(
     numericComparator({order, transform}),

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -1,4 +1,11 @@
-import { parseDate } from '../../lib/util/date';
+import { parseDate } from './date';
+import {
+  defaultOrdering,
+  identity,
+  leqToNumericOrdering,
+  lexicalCompose,
+  mapArguments,
+} from './function';
 
 export function immutableSplice(array, ...args) {
   let copy = array.slice(0);
@@ -40,49 +47,52 @@ export function insertAtIndex(array, index, value) {
  * @param {Array} arr - array to sort
  * @param {string} [order='asc'] - sort order ('asc' or 'desc')
  * @param {function} [transform=null] - transforms each element before comparison
- * @param {boolean} [lowercase=false] - converts strings to lowercase before comparison
- * @param {boolean} [orderNumDateAlpha=false] - converts numeric and date strings to integers before comparison
- * @param {string|RegExp} [dateRegex=null] - pattern used to determine wether a given string is a date without first parsing it (perf concern)
- * @param {Object} [parseDateConfig={}] - config used for parsing dates when orderNumDateAlpha is true
  * @example
  * sorted(['XX', 'A', 'g'], {transform: s => s.toLowerCase()});
  * // ['A', 'g', 'XX']
  */
-export function sorted(arr, {order=`asc`, transform=null, lowercase=false, orderNumDateAlpha=false, dateRegex=null, parseDateConfig={}}={}) {
-  dateRegex = dateRegex && new RegExp(dateRegex);
-
+export function sorted(arr, {order=`asc`, transform=null}={}) {
   return arr.slice().sort((a, b) => {
     if (transform) {
       a = transform(a);
       b = transform(b);
     }
-
-    if (lowercase) {
-      a = a.toLowerCase ? a.toLowerCase() : a;
-      b = b.toLowerCase ? b.toLowerCase() : b;
-    }
-
-    if (orderNumDateAlpha) {
-      const aNumber = Number(a.replace ? a.replace(/,/g, ``) : a);
-      const bNumber = Number(b.replace ? b.replace(/,/g, ``) : b);
-
-      if (!isNaN(aNumber) && !isNaN(bNumber)) {
-        a = aNumber;
-        b = bNumber;
-      } else if (!dateRegex || (dateRegex.test(a) && dateRegex.test(b))) {
-        const aDate = parseDate(a, parseDateConfig);
-        const bDate = parseDate(b, parseDateConfig);
-
-        if (aDate && bDate) {
-          a = aDate.getTime();
-          b = bDate.getTime();
-        }
-      }
-    }
-
     let cmp = a > b ? 1 : a < b ? -1 : 0;
     return order === `desc` ? -1 * cmp : cmp;
   });
+}
+
+const ORDERING = {
+  asc: defaultOrdering,
+  desc: leqToNumericOrdering((a, b) => b <= a),
+};
+
+export function stringComparator({order=`asc`, transform=identity}={}) {
+  return mapArguments(ORDERING[order], transform);
+}
+
+export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
+  return mapArguments(ORDERING[order], item => {
+    item = transform(item);
+    const date = (!dateRegex || new RegExp(dateRegex).test(item)) && parseDate(item, parseDateConfig);
+    return date ? date.getTime() : (order === `desc` ? 0 : Infinity); // place non-valid items last
+  });
+}
+
+export function numericComparator({order=`asc`, transform=identity}={}) {
+  return mapArguments(ORDERING[order], item => {
+    item = transform(item);
+    const number = Number(item.replace ? item.replace(/,/g, ``) : item);
+    return !isNaN(number) ? number : (order === `desc` ? 0 : Infinity); // place non-valid items last
+  });
+}
+
+export function numDateAlphaComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
+  return lexicalCompose(
+    numericComparator({order, transform}),
+    dateStringComparator({order, transform, dateRegex, parseDateConfig}),
+    stringComparator({order, transform})
+  );
 }
 
 /**

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -40,14 +40,17 @@ export function insertAtIndex(array, index, value) {
  * @param {Array} arr - array to sort
  * @param {string} [order='asc'] - sort order ('asc' or 'desc')
  * @param {function} [transform=null] - transforms each element before comparison
- * @param {function} [lowercase=false] - converts strings to lowercase before comparison
- * @param {function} [orderNumDateAlpha=false] - converts numeric and date strings to integers before comparison
+ * @param {boolean} [lowercase=false] - converts strings to lowercase before comparison
+ * @param {boolean} [orderNumDateAlpha=false] - converts numeric and date strings to integers before comparison
+ * @param {string|RegExp} [dateRegex=null] - pattern used to determine wether a given string is a date without first parsing it (perf concern)
  * @param {Object} [parseDateConfig={}] - config used for parsing dates when orderNumDateAlpha is true
  * @example
  * sorted(['XX', 'A', 'g'], {transform: s => s.toLowerCase()});
  * // ['A', 'g', 'XX']
  */
-export function sorted(arr, {order=`asc`, transform=null, lowercase=false, orderNumDateAlpha=false, parseDateConfig={}}={}) {
+export function sorted(arr, {order=`asc`, transform=null, lowercase=false, orderNumDateAlpha=false, dateRegex=null, parseDateConfig={}}={}) {
+  dateRegex = dateRegex && new RegExp(dateRegex);
+
   return arr.slice().sort((a, b) => {
     if (transform) {
       a = transform(a);
@@ -60,13 +63,13 @@ export function sorted(arr, {order=`asc`, transform=null, lowercase=false, order
     }
 
     if (orderNumDateAlpha) {
-      const aNumber = Number(a.replace ? a.replace(`,`, ``) : a);
-      const bNumber = Number(b.replace ? b.replace(`,`, ``) : b);
+      const aNumber = Number(a.replace ? a.replace(/,/g, ``) : a);
+      const bNumber = Number(b.replace ? b.replace(/,/g, ``) : b);
 
       if (!isNaN(aNumber) && !isNaN(bNumber)) {
         a = aNumber;
         b = bNumber;
-      } else {
+      } else if (!dateRegex || (dateRegex.test(a) && dateRegex.test(b))) {
         const aDate = parseDate(a, parseDateConfig);
         const bDate = parseDate(b, parseDateConfig);
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -1,5 +1,6 @@
 import { parseDate } from './date';
 import {
+  defaultOrdering,
   identity,
   leqToNumericOrdering,
   lexicalCompose,
@@ -41,9 +42,11 @@ export function insertAtIndex(array, index, value) {
   return immutableSplice(array, index, 0, value);
 }
 
+// ensure null items (used to designate invalid items) are placed last in the sorted order
+const NULL_ORDERING = leqToNumericOrdering((a, b) => a !== null || b === null);
 const SORT_ORDERING = {
-  asc: leqToNumericOrdering((a, b) => a <= b),
-  desc: leqToNumericOrdering((a, b) => b <= a),
+  asc: lexicalCompose(NULL_ORDERING, (a, b) => defaultOrdering(a, b)),
+  desc: lexicalCompose(NULL_ORDERING, (a, b) => defaultOrdering(b, a)),
 };
 
 export function baseComparator({order=`asc`, transform=identity}={}) {
@@ -54,7 +57,7 @@ export function dateStringComparator({order=`asc`, transform=identity, dateRegex
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const date = (!dateRegex || new RegExp(dateRegex).test(item)) && parseDate(item, parseDateConfig);
-    return date ? date.getTime() : (order === `desc` ? -Infinity : Infinity); // place non-valid items last
+    return date ? date.getTime() : null;
   });
 }
 
@@ -62,7 +65,7 @@ export function numericComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const number = Number(item.replace ? item.replace(/,/g, ``) : item);
-    return !isNaN(number) ? number : (order === `desc` ? -Infinity : Infinity); // place non-valid items last
+    return !isNaN(number) ? number : null;
   });
 }
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -54,7 +54,7 @@ export function dateStringComparator({order=`asc`, transform=identity, dateRegex
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const date = (!dateRegex || new RegExp(dateRegex).test(item)) && parseDate(item, parseDateConfig);
-    return date ? date.getTime() : (order === `desc` ? 0 : Infinity); // place non-valid items last
+    return date ? date.getTime() : (order === `desc` ? -Infinity : Infinity); // place non-valid items last
   });
 }
 
@@ -62,7 +62,7 @@ export function numericComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const number = Number(item.replace ? item.replace(/,/g, ``) : item);
-    return !isNaN(number) ? number : (order === `desc` ? 0 : Infinity); // place non-valid items last
+    return !isNaN(number) ? number : (order === `desc` ? -Infinity : Infinity); // place non-valid items last
   });
 }
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -1,6 +1,5 @@
 import { parseDate } from './date';
 import {
-  defaultOrdering,
   identity,
   leqToNumericOrdering,
   lexicalCompose,
@@ -42,6 +41,11 @@ export function insertAtIndex(array, index, value) {
   return immutableSplice(array, index, 0, value);
 }
 
+const SORT_ORDERING = {
+  asc: leqToNumericOrdering((a, b) => a <= b),
+  desc: leqToNumericOrdering((a, b) => b <= a),
+};
+
 /**
  * Sort array without mutating original
  * @param {Array} arr - array to sort
@@ -57,22 +61,16 @@ export function sorted(arr, {order=`asc`, transform=null}={}) {
       a = transform(a);
       b = transform(b);
     }
-    let cmp = a > b ? 1 : a < b ? -1 : 0;
-    return order === `desc` ? -1 * cmp : cmp;
+    return SORT_ORDERING[order](a, b);
   });
 }
 
-const ORDERING = {
-  asc: defaultOrdering,
-  desc: leqToNumericOrdering((a, b) => b <= a),
-};
-
 export function stringComparator({order=`asc`, transform=identity}={}) {
-  return mapArguments(ORDERING[order], transform);
+  return mapArguments(SORT_ORDERING[order], transform);
 }
 
 export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
-  return mapArguments(ORDERING[order], item => {
+  return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const date = (!dateRegex || new RegExp(dateRegex).test(item)) && parseDate(item, parseDateConfig);
     return date ? date.getTime() : (order === `desc` ? 0 : Infinity); // place non-valid items last
@@ -80,7 +78,7 @@ export function dateStringComparator({order=`asc`, transform=identity, dateRegex
 }
 
 export function numericComparator({order=`asc`, transform=identity}={}) {
-  return mapArguments(ORDERING[order], item => {
+  return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
     const number = Number(item.replace ? item.replace(/,/g, ``) : item);
     return !isNaN(number) ? number : (order === `desc` ? 0 : Infinity); // place non-valid items last

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -46,7 +46,7 @@ const SORT_ORDERING = {
   desc: leqToNumericOrdering((a, b) => b <= a),
 };
 
-export function stringComparator({order=`asc`, transform=identity}={}) {
+export function baseComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], transform);
 }
 
@@ -70,7 +70,7 @@ export function numDateAlphaComparator({order=`asc`, transform=identity, dateReg
   return lexicalCompose(
     numericComparator({order, transform}),
     dateStringComparator({order, transform, dateRegex, parseDateConfig}),
-    stringComparator({order, transform})
+    baseComparator({order, transform})
   );
 }
 
@@ -84,7 +84,7 @@ export function numDateAlphaComparator({order=`asc`, transform=identity, dateReg
  * // ['A', 'g', 'XX']
  */
 export function sorted(arr, {order=`asc`, transform=identity}={}) {
-  return arr.slice().sort(stringComparator({order, transform}));
+  return arr.slice().sort(baseComparator({order, transform}));
 }
 
 /**

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -46,25 +46,6 @@ const SORT_ORDERING = {
   desc: leqToNumericOrdering((a, b) => b <= a),
 };
 
-/**
- * Sort array without mutating original
- * @param {Array} arr - array to sort
- * @param {string} [order='asc'] - sort order ('asc' or 'desc')
- * @param {function} [transform=null] - transforms each element before comparison
- * @example
- * sorted(['XX', 'A', 'g'], {transform: s => s.toLowerCase()});
- * // ['A', 'g', 'XX']
- */
-export function sorted(arr, {order=`asc`, transform=null}={}) {
-  return arr.slice().sort((a, b) => {
-    if (transform) {
-      a = transform(a);
-      b = transform(b);
-    }
-    return SORT_ORDERING[order](a, b);
-  });
-}
-
 export function stringComparator({order=`asc`, transform=identity}={}) {
   return mapArguments(SORT_ORDERING[order], transform);
 }
@@ -91,6 +72,19 @@ export function numDateAlphaComparator({order=`asc`, transform=identity, dateReg
     dateStringComparator({order, transform, dateRegex, parseDateConfig}),
     stringComparator({order, transform})
   );
+}
+
+/**
+ * Sort array without mutating original
+ * @param {Array} arr - array to sort
+ * @param {string} [order='asc'] - sort order ('asc' or 'desc')
+ * @param {function} [transform=null] - transforms each element before comparison
+ * @example
+ * sorted(['XX', 'A', 'g'], {transform: s => s.toLowerCase()});
+ * // ['A', 'g', 'XX']
+ */
+export function sorted(arr, {order=`asc`, transform=identity}={}) {
+  return arr.slice().sort(stringComparator({order, transform}));
 }
 
 /**

--- a/lib/util/date.js
+++ b/lib/util/date.js
@@ -78,10 +78,14 @@ export function parseDate(dateString, {iso=false, startOfDay=false, endOfDay=fal
       mDate = endOfDay ? mDate.endOf(UNITS.day) : mDate;
 
       // make dates like "12/31" parse to the most recent past instance of that date
+      const fullYear = mDate.format(`YYYY`);
       const partialYear = mDate.format(`YY`);
       const month = mDate.format(`MM`);
       const day = mDate.format(`DD`);
-      if (!dateString.replace(month, ``).replace(day, ``).includes(partialYear)) { // was the year specified?
+      if ( // was the year specified?
+        !dateString.includes(fullYear) ||
+        !dateString.replace(month, ``).replace(day, ``).includes(partialYear) // ensure we don't mistakenly match on month or day
+      ) {
         mDate = mDate > moment().endOf(UNITS.day) ? mDate.subtract(1, `${UNITS.year}s`) : mDate;
       }
 

--- a/lib/util/date.js
+++ b/lib/util/date.js
@@ -78,7 +78,13 @@ export function parseDate(dateString, {iso=false, startOfDay=false, endOfDay=fal
       mDate = endOfDay ? mDate.endOf(UNITS.day) : mDate;
 
       // make dates like "12/31" parse to the most recent past instance of that date
-      mDate = mDate > moment() ? mDate.subtract(1, `${UNITS.year}s`) : mDate;
+      const partialYear = mDate.format(`YY`);
+      const month = mDate.format(`MM`);
+      const day = mDate.format(`DD`);
+      if (!dateString.replace(month, ``).replace(day, ``).includes(partialYear)) { // was the year specified?
+        mDate = mDate > moment().endOf(UNITS.day) ? mDate.subtract(1, `${UNITS.year}s`) : mDate;
+      }
+
       date = new Date(mDate);
     }
   }

--- a/lib/util/function.js
+++ b/lib/util/function.js
@@ -1,4 +1,9 @@
 /**
+ * Identity function
+ */
+export const identity = x => x;
+
+/**
  * Turn a less-than-or-equal-to operation into a function which returns 1, 0, or -1 for sorting.
  * @param {(Object,Object) => Bool} leq - function implementing leq for the desired ordering.
  */

--- a/test/util/date.js
+++ b/test/util/date.js
@@ -306,33 +306,25 @@ describe(`formatDate`, function() {
 });
 
 describe(`relativeToAbsoluteDate`, function() {
-  it(`converts a relative date integer and a unit to the expected Date object`, function() {
-    let date = new Date();
-    expect(relativeToAbsoluteDate(5, `day`)).to.eql(date.setDate(date.getDate() - 5));
+  it.only(`converts a relative date integer and a unit to the expected Date object`, function() {
+    const testCases = [
+      [5, `day`, date => date.setDate(date.getDate() - 5)],
+      [5, `month`, date => date.setMonth(date.getMonth() - 5)],
+      [5, `year`, date => date.setFullYear(date.getFullYear() - 5)],
+      [-100, `day`, date => date.setDate(date.getDate() + 100)],
+      [-100, `month`, date => date.setMonth(date.getMonth() + 100)],
+      [-100, `year`, date => date.setFullYear(date.getFullYear() + 100)],
+      [0, `day`, date => date],
+      [0, `month`, date => date],
+      [0, `year`, date => date],
+    ];
 
-    date = new Date();
-    expect(relativeToAbsoluteDate(5, `month`)).to.eql(date.setMonth(date.getMonth() - 5));
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(5, `year`)).to.eql(date.setFullYear(date.getFullYear() - 5));
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(-100, `day`)).to.eql(date.setDate(date.getDate() + 100));
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(-100, `month`)).to.eql(date.setMonth(date.getMonth() + 100));
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(-100, `year`)).to.eql(date.setFullYear(date.getFullYear() + 100));
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(0, `day`)).to.eql(date);
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(0, `month`)).to.eql(date);
-
-    date = new Date();
-    expect(relativeToAbsoluteDate(0, `year`)).to.eql(date);
+    testCases.forEach(([value, unit, setExpected]) => {
+      const actual = relativeToAbsoluteDate(value, unit);
+      const expected = new Date();
+      setExpected(expected);
+      expect(actual.setHours(0, 0, 0, 0)).to.eql(expected.setHours(0, 0, 0, 0));
+    });
   });
 
   it(`returns null if invalid input is passed`, function() {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -7,7 +7,7 @@ import {
   truncateMiddle,
   unique,
 
-  stringComparator,
+  baseComparator,
   dateStringComparator,
   numericComparator,
   numDateAlphaComparator,
@@ -74,19 +74,27 @@ describe('sorted()', function() {
   });
 });
 
-describe(`stringComparator()`, function() {
+describe(`baseComparator()`, function() {
   it('sorts strings', function() {
-    expect(['a', 'zzz', 'moo'].sort(stringComparator())).to.eql(['a', 'moo', 'zzz']);
-    expect(['a', 'zzz', 'moo'].sort(stringComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
+    expect(['a', 'zzz', 'moo'].sort(baseComparator())).to.eql(['a', 'moo', 'zzz']);
+    expect(['a', 'zzz', 'moo'].sort(baseComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
+  });
+
+  it(`sorts numbers`, function() {
+    expect([9.876, 11, 0, -12000].sort(baseComparator()))
+      .to.eql([-12000, 0, 9.876, 11]);
+
+    expect([9.876, 11, 0, -12000].sort(baseComparator({order: `desc`})))
+      .to.eql([11, 9.876, 0, -12000]);
   });
 
   it('can sort based on a given transformation', function() {
-    expect(['a', 'zzz', 'MOO'].sort(stringComparator({
+    expect(['a', 'zzz', 'MOO'].sort(baseComparator({
       order: 'desc',
       transform: s => s.toLowerCase(),
     }))).to.eql(['zzz', 'MOO', 'a']);
 
-    expect([{a: 5}, {a: 2}, {a: 3}].sort(stringComparator({
+    expect([{a: 5}, {a: 2}, {a: 3}].sort(baseComparator({
       transform: o => o.a,
     }))).to.eql([{a: 2}, {a: 3}, {a: 5}]);
   });
@@ -166,8 +174,8 @@ describe(`dateStringComparator()`, function() {
 
 describe(`numDateAlphaComparator()`, function() {
   it('sorts strings', function() {
-    expect(['a', 'zzz', 'moo'].sort(stringComparator())).to.eql(['a', 'moo', 'zzz']);
-    expect(['a', 'zzz', 'moo'].sort(stringComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
+    expect(['a', 'zzz', 'moo'].sort(numDateAlphaComparator())).to.eql(['a', 'moo', 'zzz']);
+    expect(['a', 'zzz', 'moo'].sort(numDateAlphaComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
   });
 
   it(`sorts numeric strings`, function() {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -83,11 +83,18 @@ describe('sorted()', function() {
       .to.eql(['January 8th, 2000', '4-1-15', '12/31/16']);
   });
 
-  it('can properly sort iso date strings', function() {
+  it('can properly sort date strings with a parse config', function() {
     expect(sorted(['2016-12-31', '2000-08-01', '2015-04-01'], {
       orderNumDateAlpha: true,
-      parseDateConfig: {iso: true},
+      parseDateConfig: {iso: true, utc: true},
     })).to.eql(['2000-08-01', '2015-04-01', '2016-12-31']);
+  });
+
+  it('can properly sort date strings that match a specific regex', function() {
+    expect(sorted(['apr 10 2015', '2016-12-31', '2000-08-01', 'feb 4 2012'], {
+      orderNumDateAlpha: true,
+      dateRegex: `\d\d\d\d-\d\d-\d\d`,
+    })).to.eql(['2000-08-01', '2016-12-31', 'apr 10 2015', 'feb 4 2012']);
   });
 });
 

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -58,10 +58,36 @@ describe('sorted()', function() {
   });
 
   it('can sort based on a given transformation', function() {
-    expect(sorted(['a', 'zzz', 'MOO'], {
-      order: 'desc',
-      transform: s => s.toLowerCase(),
-    })).to.eql(['zzz', 'MOO', 'a']);
+    expect(JSON.stringify(sorted([{a: 5}, {a: 2}, {a: 3}], {
+      transform: o => o.a,
+    }))).to.eql(JSON.stringify([{a: 2}, {a: 3}, {a: 5}]));
+  });
+
+  it('can convert strings to lowercase before sorting', function() {
+    expect(sorted(['zzz', 'a', 'MOO'], {lowercase: true}))
+      .to.eql(['a', 'MOO', 'zzz']);
+  });
+
+  it('can properly sort numeric strings', function() {
+    expect(sorted(['9.876', '11', '000', '-12,000'], {orderNumDateAlpha: true}))
+      .to.eql(['-12,000', '000', '9.876', '11']);
+  });
+
+  it('can properly sort numbers', function() {
+    expect(sorted([9.876, 11, 0, -12000], {orderNumDateAlpha: true}))
+      .to.eql([-12000, 0, 9.876, 11]);
+  });
+
+  it('can properly sort date strings', function() {
+    expect(sorted(['12/31/16', 'January 8th, 2000', '4-1-15'], {orderNumDateAlpha: true}))
+      .to.eql(['January 8th, 2000', '4-1-15', '12/31/16']);
+  });
+
+  it('can properly sort iso date strings', function() {
+    expect(sorted(['2016-12-31', '2000-08-01', '2015-04-01'], {
+      orderNumDateAlpha: true,
+      parseDateConfig: {iso: true},
+    })).to.eql(['2000-08-01', '2015-04-01', '2016-12-31']);
   });
 });
 

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -25,48 +25,48 @@ import {
   truncateToWidth
 } from '../../lib/util';
 
-describe('pluralize()', function() {
-  it('defaults to adding s', function() {
-    expect(pluralize('day', 3)).to.equal('days');
+describe(`pluralize()`, function() {
+  it(`defaults to adding s`, function() {
+    expect(pluralize(`day`, 3)).to.equal(`days`);
   });
 
-  it('does not pluralize singulars', function() {
-    expect(pluralize('wombat', 1)).to.equal('wombat');
+  it(`does not pluralize singulars`, function() {
+    expect(pluralize(`wombat`, 1)).to.equal(`wombat`);
   });
 
-  it('pluralizes 0 of something', function() {
-    expect(pluralize('helicopter', 0)).to.equal('helicopters');
+  it(`pluralizes 0 of something`, function() {
+    expect(pluralize(`helicopter`, 0)).to.equal(`helicopters`);
   });
 
-  it('uses third argument to pluralize', function() {
-    expect(pluralize('die', 4, 'dice')).to.equal('dice');
+  it(`uses third argument to pluralize`, function() {
+    expect(pluralize(`die`, 4, `dice`)).to.equal(`dice`);
   });
 });
 
-describe('sorted()', function() {
-  it('defaults to normal ascending sort() behavior', function() {
+describe(`sorted()`, function() {
+  it(`defaults to normal ascending sort() behavior`, function() {
     expect(sorted([5, 2, 4, 1])).to.eql([1, 2, 4, 5]);
   });
 
-  it('does not mutate its array argument', function() {
+  it(`does not mutate its array argument`, function() {
     const arr = [5, 2, 4, 1];
     expect(sorted(arr)).to.eql([1, 2, 4, 5]);
     expect(arr).to.eql([5, 2, 4, 1]);
   });
 
-  it('sorts strings', function() {
-    expect(sorted(['a', 'zzz', 'moo'])).to.eql(['a', 'moo', 'zzz']);
+  it(`sorts strings`, function() {
+    expect(sorted([`a`, `zzz`, `moo`])).to.eql([`a`, `moo`, `zzz`]);
   });
 
-  it('can sort descending', function() {
-    expect(sorted(['a', 'zzz', 'moo'], {order: 'desc'})).to.eql(['zzz', 'moo', 'a']);
+  it(`can sort descending`, function() {
+    expect(sorted([`a`, `zzz`, `moo`], {order: `desc`})).to.eql([`zzz`, `moo`, `a`]);
   });
 
-  it('can sort based on a given transformation', function() {
-    expect(sorted(['a', 'zzz', 'MOO'], {
-      order: 'desc',
+  it(`can sort based on a given transformation`, function() {
+    expect(sorted([`a`, `zzz`, `MOO`], {
+      order: `desc`,
       transform: s => s.toLowerCase(),
-    })).to.eql(['zzz', 'MOO', 'a']);
+    })).to.eql([`zzz`, `MOO`, `a`]);
 
     expect(sorted([{a: 5}, {a: 2}, {a: 3}], {
       transform: o => o.a,
@@ -75,9 +75,9 @@ describe('sorted()', function() {
 });
 
 describe(`baseComparator()`, function() {
-  it('sorts strings', function() {
-    expect(['a', 'zzz', 'moo'].sort(baseComparator())).to.eql(['a', 'moo', 'zzz']);
-    expect(['a', 'zzz', 'moo'].sort(baseComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
+  it(`sorts strings`, function() {
+    expect([`a`, `zzz`, `moo`].sort(baseComparator())).to.eql([`a`, `moo`, `zzz`]);
+    expect([`a`, `zzz`, `moo`].sort(baseComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
   });
 
   it(`sorts numbers`, function() {
@@ -88,11 +88,11 @@ describe(`baseComparator()`, function() {
       .to.eql([11, 9.876, 0, -12000]);
   });
 
-  it('can sort based on a given transformation', function() {
-    expect(['a', 'zzz', 'MOO'].sort(baseComparator({
-      order: 'desc',
+  it(`can sort based on a given transformation`, function() {
+    expect([`a`, `zzz`, `MOO`].sort(baseComparator({
+      order: `desc`,
       transform: s => s.toLowerCase(),
-    }))).to.eql(['zzz', 'MOO', 'a']);
+    }))).to.eql([`zzz`, `MOO`, `a`]);
 
     expect([{a: 5}, {a: 2}, {a: 3}].sort(baseComparator({
       transform: o => o.a,
@@ -117,15 +117,23 @@ describe(`numericComparator()`, function() {
       .to.eql([11, 9.876, 0, -12000]);
   });
 
-  it('can sort based on a given transformation', function() {
-    expect([3, 4, 5].sort(numericComparator({
-      transform: n => n % 2,
-    }))).to.eql([4, 3, 5]);
+  it(`places invalid numeric strings last in the sorted order for asc and desc`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas une nombre`].sort(numericComparator()))
+      .to.eql([`-12,000`, `000`, `9.876`, `11`, `Ceci n'est pas une nombre`]);
 
-    expect([3, 4, 5].sort(numericComparator({
-      order: 'desc',
-      transform: n => n % 2,
-    }))).to.eql([3, 5, 4]);
+    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas une nombre`].sort(numericComparator({order: `desc`})))
+      .to.eql([`11`, `9.876`, `000`, `-12,000`, `Ceci n'est pas une nombre`]);
+  });
+
+  it(`can sort based on a given transformation`, function() {
+    expect([3, 5, 7].sort(numericComparator({
+      transform: n => n % 3,
+    }))).to.eql([3, 7, 5]);
+
+    expect([3, 5, 7].sort(numericComparator({
+      order: `desc`,
+      transform: n => n % 3,
+    }))).to.eql([5, 7, 3]);
   });
 });
 
@@ -149,6 +157,14 @@ describe(`dateStringComparator()`, function() {
     }))).to.eql([`2016-12-31`, `2015-04-01`, `2000-08-01`]);
   });
 
+  it(`places invalid date strings last in the sorted order for asc and desc`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator()))
+      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`, `Ceci n'est pas une date`]);
+
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator({order: `desc`})))
+      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`, `Ceci n'est pas une date`]);
+  });
+
   it(`sorts date strings that match a specific regex`, function() {
     expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(dateStringComparator({
       dateRegex: /\d\d\d\d-\d\d-\d\d/,
@@ -160,22 +176,22 @@ describe(`dateStringComparator()`, function() {
     }))).to.eql([`2016-12-31`, `2000-08-01`, `apr 10 2015`, `feb 4 2012`]);
   });
 
-  it('can sort based on a given transformation', function() {
-    expect(['12/6/2002', '12/5/2003', '12/7/2001'].sort(dateStringComparator({
+  it(`can sort based on a given transformation`, function() {
+    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
       transform: s => s.slice(0, 4),
-    }))).to.eql(['12/5/2003', '12/6/2002', '12/7/2001']);
+    }))).to.eql([`12/5/2003`, `12/6/2002`, `12/7/2001`]);
 
-    expect(['12/6/2002', '12/5/2003', '12/7/2001'].sort(dateStringComparator({
+    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
       order: `desc`,
       transform: s => s.slice(0, 4),
-    }))).to.eql(['12/7/2001', '12/6/2002', '12/5/2003']);
+    }))).to.eql([`12/7/2001`, `12/6/2002`, `12/5/2003`]);
   });
 });
 
 describe(`numDateAlphaComparator()`, function() {
-  it('sorts strings', function() {
-    expect(['a', 'zzz', 'moo'].sort(numDateAlphaComparator())).to.eql(['a', 'moo', 'zzz']);
-    expect(['a', 'zzz', 'moo'].sort(numDateAlphaComparator({order: 'desc'}))).to.eql(['zzz', 'moo', 'a']);
+  it(`sorts strings`, function() {
+    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator())).to.eql([`a`, `moo`, `zzz`]);
+    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
   });
 
   it(`sorts numeric strings`, function() {
@@ -224,11 +240,11 @@ describe(`numDateAlphaComparator()`, function() {
     }))).to.eql([`2016-12-31`, `2000-08-01`, `feb 4 2012`, `apr 10 2015`]);
   });
 
-  it('can sort based on a given transformation', function() {
-    expect(['a', 'zzz', 'MOO'].sort(numDateAlphaComparator({
-      order: 'desc',
+  it(`can sort based on a given transformation`, function() {
+    expect([`a`, `zzz`, `MOO`].sort(numDateAlphaComparator({
+      order: `desc`,
       transform: s => s.toLowerCase(),
-    }))).to.eql(['zzz', 'MOO', 'a']);
+    }))).to.eql([`zzz`, `MOO`, `a`]);
 
     expect([{a: 5}, {a: 2}, {a: 3}].sort(numDateAlphaComparator({
       transform: o => o.a,
@@ -236,67 +252,67 @@ describe(`numDateAlphaComparator()`, function() {
   });
 });
 
-describe('sum()', function() {
-  it('adds all array members together', function() {
+describe(`sum()`, function() {
+  it(`adds all array members together`, function() {
     expect(sum([5, 10, 20])).to.equal(35);
   });
 
-  it('returns 0 for empty arrays', function() {
+  it(`returns 0 for empty arrays`, function() {
     expect(sum([])).to.equal(0);
   });
 
-  it('works for array-like non-array objects', function() {
+  it(`works for array-like non-array objects`, function() {
     expect(sum({length: 2, 0: 15, 1: 3})).to.equal(18);
   });
 });
 
-describe('truncateMiddle()', function() {
-  it('works when string.length is len+1', function() {
-    expect(truncateMiddle('frogs', 4)).to.eql('f...');
+describe(`truncateMiddle()`, function() {
+  it(`works when string.length is len+1`, function() {
+    expect(truncateMiddle(`frogs`, 4)).to.eql(`f...`);
   })
 
-  it('only truncates if necessary', function() {
-    expect(truncateMiddle('mixpanel', 8)).to.eql('mixpanel');
+  it(`only truncates if necessary`, function() {
+    expect(truncateMiddle(`mixpanel`, 8)).to.eql(`mixpanel`);
   });
 
-  it('truncates intelligently if length is small', function() {
-    expect(truncateMiddle('mixpanel', 2)).to.eql('mi');
+  it(`truncates intelligently if length is small`, function() {
+    expect(truncateMiddle(`mixpanel`, 2)).to.eql(`mi`);
   });
 
-  it('returns empty string if length is 0', function() {
-    expect(truncateMiddle('mixpanel', 0)).to.eql('');
+  it(`returns empty string if length is 0`, function() {
+    expect(truncateMiddle(`mixpanel`, 0)).to.eql(``);
   });
 
-  it('truncates in middle of long text', function() {
-    const loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
-    expect(truncateMiddle(loremIpsum, 20)).to.eql('Lorem ips...laborum.');
+  it(`truncates in middle of long text`, function() {
+    const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+    expect(truncateMiddle(loremIpsum, 20)).to.eql(`Lorem ips...laborum.`);
     expect(truncateMiddle(loremIpsum, 12).length).to.eql(12);
   });
 
-  it('handles newlines and whitespace well', function() {
-    const whiteSpace = 'Lorem \n ipsum \t dolor \r sit \w amet,';
+  it(`handles newlines and whitespace well`, function() {
+    const whiteSpace = `Lorem \n ipsum \t dolor \r sit \w amet,`;
     expect(truncateMiddle(whiteSpace, 17).length).to.eql(17);
   });
 });
 
-describe('immutableSplice()', function() {
-  it('removes items by positive index', function() {
-    expect(immutableSplice(['a', 'b', 'c', 'd', 'e'], 1, 2)).to.eql(['a', 'd', 'e']);
+describe(`immutableSplice()`, function() {
+  it(`removes items by positive index`, function() {
+    expect(immutableSplice([`a`, `b`, `c`, `d`, `e`], 1, 2)).to.eql([`a`, `d`, `e`]);
   });
 
-  it('removes items by negative index', function() {
-    expect(immutableSplice(['a', 'b', 'c', 'd', 'e'], -3, 2)).to.eql(['a', 'b', 'e']);
+  it(`removes items by negative index`, function() {
+    expect(immutableSplice([`a`, `b`, `c`, `d`, `e`], -3, 2)).to.eql([`a`, `b`, `e`]);
   });
 
-  it('inserts items by positive index', function() {
-    expect(immutableSplice(['a', 'b', 'c', 'd', 'e'], 1, 1, '$', '*')).to.eql(['a', '$', '*', 'c', 'd', 'e']);
+  it(`inserts items by positive index`, function() {
+    expect(immutableSplice([`a`, `b`, `c`, `d`, `e`], 1, 1, `$`, `*`)).to.eql([`a`, `$`, `*`, `c`, `d`, `e`]);
   });
 
-  it('inserts items by negative index', function() {
-    expect(immutableSplice(['a', 'b', 'c', 'd', 'e'], -3, 1, '$', '*')).to.eql(['a', 'b', '$', '*', 'd', 'e']);
+  it(`inserts items by negative index`, function() {
+    expect(immutableSplice([`a`, `b`, `c`, `d`, `e`], -3, 1, `$`, `*`)).to.eql([`a`, `b`, `$`, `*`, `d`, `e`]);
   });
 
-  it('behaves the same way as Array.prototype.splice when removing', function() {
+  it(`behaves the same way as Array.prototype.splice when removing`, function() {
     let expected, actual;
 
     for (let start = -3; start < 3; start++) {
@@ -312,7 +328,7 @@ describe('immutableSplice()', function() {
     }
   });
 
-  it('behaves the same way as Array.prototype.splice when inserting', function() {
+  it(`behaves the same way as Array.prototype.splice when inserting`, function() {
     let expected, actual, items;
 
     for (let start = -3; start < 3; start++) {
@@ -334,95 +350,95 @@ describe('immutableSplice()', function() {
   });
 });
 
-describe('removeByIndex()', function() {
-  it('removes items by positive index', function() {
-    expect(removeByIndex(['a', 'b', 'c', 'd', 'e'], 2)).to.eql(['a','b','d','e']);
+describe(`removeByIndex()`, function() {
+  it(`removes items by positive index`, function() {
+    expect(removeByIndex([`a`, `b`, `c`, `d`, `e`], 2)).to.eql([`a`,`b`,`d`,`e`]);
   });
 
-  it('removes items by negative index', function() {
-    expect(removeByIndex(['a', 'b', 'c', 'd', 'e'], -2)).to.eql(['a','b','c','e']);
+  it(`removes items by negative index`, function() {
+    expect(removeByIndex([`a`, `b`, `c`, `d`, `e`], -2)).to.eql([`a`,`b`,`c`,`e`]);
   });
 
-  it('throws an exception if index is out of range', function() {
-    expect(() => removeByIndex(['a', 'b', 'c', 'd', 'e'], 10)).to.throwException(/IndexError/);
-    expect(() => removeByIndex(['a', 'b', 'c', 'd', 'e'], -10)).to.throwException(/IndexError/);
-  });
-});
-
-describe('removeByValue()', function() {
-  it('removes items by value', function() {
-    expect(removeByValue(['a', 'b', 'c', 'd', 'e'], 'c')).to.eql(['a', 'b', 'd', 'e']);
-  });
-
-  it('throws an exception if value is not present in array', function() {
-    expect(() => removeByValue(['a', 'b', 'c', 'd', 'e'], '$')).to.throwException(/ValueError/);
+  it(`throws an exception if index is out of range`, function() {
+    expect(() => removeByIndex([`a`, `b`, `c`, `d`, `e`], 10)).to.throwException(/IndexError/);
+    expect(() => removeByIndex([`a`, `b`, `c`, `d`, `e`], -10)).to.throwException(/IndexError/);
   });
 });
 
-describe('replaceByIndex()', function() {
-  it('replaces items by positive index', function() {
-    expect(replaceByIndex(['a', 'b', 'c', 'd', 'e'], 2, '$')).to.eql(['a', 'b', '$', 'd', 'e']);
+describe(`removeByValue()`, function() {
+  it(`removes items by value`, function() {
+    expect(removeByValue([`a`, `b`, `c`, `d`, `e`], `c`)).to.eql([`a`, `b`, `d`, `e`]);
   });
 
-  it('replaces items by negative index', function() {
-    expect(replaceByIndex(['a', 'b', 'c', 'd', 'e'], -2, '$')).to.eql(['a', 'b', 'c', '$', 'e']);
-  });
-
-  it('throws an exception if index is out of range', function() {
-    expect(() => replaceByIndex(['a', 'b', 'c', 'd', 'e'], 10, '$')).to.throwException(/IndexError/);
-    expect(() => replaceByIndex(['a', 'b', 'c', 'd', 'e'], -10, '$')).to.throwException(/IndexError/);
+  it(`throws an exception if value is not present in array`, function() {
+    expect(() => removeByValue([`a`, `b`, `c`, `d`, `e`], `$`)).to.throwException(/ValueError/);
   });
 });
 
-describe('insertAtIndex()', function() {
-  it('inserts items by positive index', function() {
-    expect(insertAtIndex(['a', 'b', 'c', 'd', 'e'], 2, '$')).to.eql(['a', 'b', '$', 'c', 'd', 'e']);
+describe(`replaceByIndex()`, function() {
+  it(`replaces items by positive index`, function() {
+    expect(replaceByIndex([`a`, `b`, `c`, `d`, `e`], 2, `$`)).to.eql([`a`, `b`, `$`, `d`, `e`]);
   });
 
-  it('inserts items by negative index', function() {
-    expect(insertAtIndex(['a', 'b', 'c', 'd', 'e'], -2, '$')).to.eql(['a', 'b', 'c', '$', 'd', 'e']);
+  it(`replaces items by negative index`, function() {
+    expect(replaceByIndex([`a`, `b`, `c`, `d`, `e`], -2, `$`)).to.eql([`a`, `b`, `c`, `$`, `e`]);
   });
 
-  it('throws an exception if index is out of range', function() {
-    expect(() => insertAtIndex(['a', 'b', 'c', 'd', 'e'], 10, '$')).to.throwException(/IndexError/);
-    expect(() => insertAtIndex(['a', 'b', 'c', 'd', 'e'], -10, '$')).to.throwException(/IndexError/);
-  });
-
-  it('appends item if given index === array.length', function() {
-    const array = ['a', 'b', 'c', 'd', 'e'];
-    expect(insertAtIndex(array, array.length, '$')).to.eql(['a', 'b', 'c', 'd', 'e', '$']);
+  it(`throws an exception if index is out of range`, function() {
+    expect(() => replaceByIndex([`a`, `b`, `c`, `d`, `e`], 10, `$`)).to.throwException(/IndexError/);
+    expect(() => replaceByIndex([`a`, `b`, `c`, `d`, `e`], -10, `$`)).to.throwException(/IndexError/);
   });
 });
 
-describe('unique()', function() {
-  it('removes duplicate items from an array', function() {
+describe(`insertAtIndex()`, function() {
+  it(`inserts items by positive index`, function() {
+    expect(insertAtIndex([`a`, `b`, `c`, `d`, `e`], 2, `$`)).to.eql([`a`, `b`, `$`, `c`, `d`, `e`]);
+  });
+
+  it(`inserts items by negative index`, function() {
+    expect(insertAtIndex([`a`, `b`, `c`, `d`, `e`], -2, `$`)).to.eql([`a`, `b`, `c`, `$`, `d`, `e`]);
+  });
+
+  it(`throws an exception if index is out of range`, function() {
+    expect(() => insertAtIndex([`a`, `b`, `c`, `d`, `e`], 10, `$`)).to.throwException(/IndexError/);
+    expect(() => insertAtIndex([`a`, `b`, `c`, `d`, `e`], -10, `$`)).to.throwException(/IndexError/);
+  });
+
+  it(`appends item if given index === array.length`, function() {
+    const array = [`a`, `b`, `c`, `d`, `e`];
+    expect(insertAtIndex(array, array.length, `$`)).to.eql([`a`, `b`, `c`, `d`, `e`, `$`]);
+  });
+});
+
+describe(`unique()`, function() {
+  it(`removes duplicate items from an array`, function() {
     expect(unique([1, 2, 2, 3, 4, 4, 4, 5])).to.eql([1, 2, 3, 4, 5]);
   });
 
-  it('does not modify the original array', function() {
+  it(`does not modify the original array`, function() {
     let array = [1, 2, 2, 3, 4, 4, 4, 5];
     unique(array);
     expect(array).to.eql([1, 2, 2, 3, 4, 4, 4, 5]);
   });
 
-  it('works with an empty array', function() {
+  it(`works with an empty array`, function() {
     expect(unique([])).to.eql([]);
   });
 
-  it('removes duplicates of non-array/object types', function() {
+  it(`removes duplicates of non-array/object types`, function() {
     expect(unique([
-      0, 0, -1, -1, 'abc', 'abc', null, null, undefined, undefined,
-    ])).to.eql([0, -1, 'abc', null, undefined]);
+      0, 0, -1, -1, `abc`, `abc`, null, null, undefined, undefined,
+    ])).to.eql([0, -1, `abc`, null, undefined]);
   });
 
-  it('throws an exception for non-array inputs', function() {
-    [1, 'abc', {}, null, undefined].forEach(input =>
+  it(`throws an exception for non-array inputs`, function() {
+    [1, `abc`, {}, null, undefined].forEach(input =>
       expect(() => unique(input)).to.throwException()
     );
   });
 
-  context('when no hash function is provided', function() {
-    it('does not remove duplicate arrays or objects', function() {
+  context(`when no hash function is provided`, function() {
+    it(`does not remove duplicate arrays or objects`, function() {
       expect(unique([
         [], [], {}, {}, [1, 2, 3], [1, 2, 3], {a: 1}, {a: 1},
       ])).to.eql([
@@ -431,12 +447,12 @@ describe('unique()', function() {
     });
   });
 
-  context('when a hash function is provided', function() {
+  context(`when a hash function is provided`, function() {
     const getHashFunc = keys =>
-      obj => keys.map(key => obj[key]).join(':');
+      obj => keys.map(key => obj[key]).join(`:`);
 
-    it('removes duplicate objects from an array', function() {
-      const hash = getHashFunc(['a', 'b']);
+    it(`removes duplicate objects from an array`, function() {
+      const hash = getHashFunc([`a`, `b`]);
       expect(unique([
         {a: 1, b: 2}, {a: 1, b: 4}, {a: 1, b: 2},
       ], {hash})).to.eql([
@@ -444,7 +460,7 @@ describe('unique()', function() {
       ]);
     });
 
-    it('removes duplicate arrays from an array', function() {
+    it(`removes duplicate arrays from an array`, function() {
       const hash = getHashFunc([1, 3]);
       expect(unique([
         [1, 2, 3, 4, 5], [1, 3, 4, 2, 5], [2, 2, 4, 4 ,5],
@@ -453,12 +469,12 @@ describe('unique()', function() {
       ]);
     });
 
-    it('removes duplicates of objects containing all types', function() {
-      const hash = getHashFunc(['a', 'b']);
+    it(`removes duplicates of objects containing all types`, function() {
+      const hash = getHashFunc([`a`, `b`]);
       expect(unique([
-        {a: 1, b: 'abc'}, {a: 1, b: 'abc'}, {a: null, b: undefined}, {a: null, b: undefined}, {a: [], b: {}}, {a: [], b: {}},
+        {a: 1, b: `abc`}, {a: 1, b: `abc`}, {a: null, b: undefined}, {a: null, b: undefined}, {a: [], b: {}}, {a: [], b: {}},
       ], {hash})).to.eql([
-        {a: 1, b: 'abc'}, {a: null, b: undefined}, {a: [], b: {}},
+        {a: 1, b: `abc`}, {a: null, b: undefined}, {a: [], b: {}},
       ]);
     });
   });
@@ -481,8 +497,8 @@ const timeseriesResultObj = {
   },
 };
 
-describe('nestedObjectRolling', function() {
-  it('supports rolling average on the leaf nodes without enought data for a window', function() {
+describe(`nestedObjectRolling`, function() {
+  it(`supports rolling average on the leaf nodes without enought data for a window`, function() {
     const arr = nestedObjectRolling(timeseriesResultObj, 7);
     expect(arr).to.eql({
       US: {
@@ -502,7 +518,7 @@ describe('nestedObjectRolling', function() {
     });
   });
 
-  it('supports rolling average on the leaf nodes with more data than a window', function() {
+  it(`supports rolling average on the leaf nodes with more data than a window`, function() {
     const arr = nestedObjectRolling(timeseriesResultObj, 3);
     expect(arr).to.eql({
       US: {
@@ -523,30 +539,30 @@ describe('nestedObjectRolling', function() {
   });
 });
 
-describe('binarySearch', function() {
-  it('finds the first positive value in a range', function() {
+describe(`binarySearch`, function() {
+  it(`finds the first positive value in a range`, function() {
     expect(binarySearch(0, 50, n => n - 10)).to.eql(10);
   });
 });
 
-describe('truncateToWidth', function() {
-  it('finds the largest truncation which fits in the given space and font', function() {
-    expect(truncateToWidth('abcdefghijklmnopqrstuvwxyz', '12px Arial', 35)).to.eql('ab...z')
-    expect(truncateToWidth('abcdefghijklmnopqrstuvwxyz', '12px Arial', 25)).to.eql('a...z')
-    expect(truncateToWidth('abcdefghijklmnopqrstuvwxyz', '22px Arial', 35)).to.eql('ab')
+describe(`truncateToWidth`, function() {
+  it(`finds the largest truncation which fits in the given space and font`, function() {
+    expect(truncateToWidth(`abcdefghijklmnopqrstuvwxyz`, `12px Arial`, 35)).to.eql(`ab...z`)
+    expect(truncateToWidth(`abcdefghijklmnopqrstuvwxyz`, `12px Arial`, 25)).to.eql(`a...z`)
+    expect(truncateToWidth(`abcdefghijklmnopqrstuvwxyz`, `22px Arial`, 35)).to.eql(`ab`)
   });
 });
 
-describe('truncateToElement', function() {
-  it('finds the largest truncation which fits in the given element, taking account of font / padding', function() {
-    var elem = document.createElement('div');
+describe(`truncateToElement`, function() {
+  it(`finds the largest truncation which fits in the given element, taking account of font / padding`, function() {
+    var elem = document.createElement(`div`);
     document.body.appendChild(elem);
-    elem.style.width = '35px';
-    elem.style.font = '12px Arial';
-    elem.style.padding = '0px';
-    expect(truncateToElement('abcdefghijklmnopqrstuvwxyz', elem)).to.eql('ab...z')
-    elem.style.padding = '10px';
-    expect(truncateToElement('abcdefghijklmnopqrstuvwxyz', elem)).to.eql('ab...z')
+    elem.style.width = `35px`;
+    elem.style.font = `12px Arial`;
+    elem.style.padding = `0px`;
+    expect(truncateToElement(`abcdefghijklmnopqrstuvwxyz`, elem)).to.eql(`ab...z`)
+    elem.style.padding = `10px`;
+    expect(truncateToElement(`abcdefghijklmnopqrstuvwxyz`, elem)).to.eql(`ab...z`)
     document.body.removeChild(elem);
   });
 });

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -43,6 +43,233 @@ describe(`pluralize()`, function() {
   });
 });
 
+describe(`baseComparator()`, function() {
+  it(`sorts strings (asc)`, function() {
+    expect([`a`, `zzz`, `moo`].sort(baseComparator())).to.eql([`a`, `moo`, `zzz`]);
+  });
+
+  it(`sorts strings (desc)`, function() {
+    expect([`a`, `zzz`, `moo`].sort(baseComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
+  });
+
+  it(`sorts numbers (asc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(baseComparator()))
+      .to.eql([-12000, 0, 9.876, 11]);
+  });
+
+  it(`sorts numbers (desc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(baseComparator({order: `desc`})))
+      .to.eql([11, 9.876, 0, -12000]);
+  });
+
+  it(`sorts based on a given transformation (asc)`, function() {
+    expect([{a: 5}, {a: 2}, {a: 3}].sort(baseComparator({
+      transform: o => o.a,
+    }))).to.eql([{a: 2}, {a: 3}, {a: 5}]);
+
+    expect([`a`, `zzz`, `MOO`].sort(baseComparator({
+      transform: s => s.toLowerCase(),
+    }))).to.eql([`a`, `MOO`, `zzz`]);
+  });
+
+  it(`sorts based on a given transformation (desc)`, function() {
+    expect([{a: 5}, {a: 2}, {a: 3}].sort(baseComparator({
+      order: `desc`,
+      transform: o => o.a,
+    }))).to.eql([{a: 5}, {a: 3}, {a: 2}]);
+
+    expect([`a`, `zzz`, `MOO`].sort(baseComparator({
+      order: `desc`,
+      transform: s => s.toLowerCase(),
+    }))).to.eql([`zzz`, `MOO`, `a`]);
+  });
+});
+
+describe(`numericComparator()`, function() {
+  it(`sorts numeric strings (asc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`].sort(numericComparator()))
+      .to.eql([`-12,000`, `000`, `9.876`, `11`]);
+  });
+
+  it(`sorts numeric strings (desc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`].sort(numericComparator({order: `desc`})))
+      .to.eql([`11`, `9.876`, `000`, `-12,000`]);
+  });
+
+  it(`sorts numbers (asc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(numericComparator()))
+      .to.eql([-12000, 0, 9.876, 11]);
+  });
+
+  it(`sorts numbers (desc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(numericComparator({order: `desc`})))
+      .to.eql([11, 9.876, 0, -12000]);
+  });
+
+  it(`places invalid numeric strings last in the sorted order (asc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas un nombre`].sort(numericComparator()))
+      .to.eql([`-12,000`, `000`, `9.876`, `11`, `Ceci n'est pas un nombre`]);
+  });
+
+  it(`places invalid numeric strings last in the sorted order (desc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas un nombre`].sort(numericComparator({order: `desc`})))
+      .to.eql([`11`, `9.876`, `000`, `-12,000`, `Ceci n'est pas un nombre`]);
+  });
+
+  it(`sorts based on a given transformation (asc)`, function() {
+    expect([3, 5, 7].sort(numericComparator({
+      transform: n => n % 3,
+    }))).to.eql([3, 7, 5]);
+  });
+
+  it(`sorts based on a given transformation (desc)`, function() {
+    expect([3, 5, 7].sort(numericComparator({
+      order: `desc`,
+      transform: n => n % 3,
+    }))).to.eql([5, 7, 3]);
+  });
+});
+
+describe(`dateStringComparator()`, function() {
+  it(`sorts date strings (asc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(dateStringComparator()))
+      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`]);
+  });
+
+  it(`sorts date strings (desc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(dateStringComparator({order: `desc`})))
+      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`]);
+  });
+
+  it(`sorts date strings with a parse config (asc)`, function() {
+    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(dateStringComparator({
+      parseDateConfig: {iso: true, utc: true},
+    }))).to.eql([`2000-08-01`, `2015-04-01`, `2016-12-31`]);
+  });
+
+  it(`sorts date strings with a parse config (desc)`, function() {
+    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(dateStringComparator({
+      order: `desc`,
+      parseDateConfig: {iso: true, utc: true},
+    }))).to.eql([`2016-12-31`, `2015-04-01`, `2000-08-01`]);
+  });
+
+  it(`places invalid date strings last in the sorted order (asc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator()))
+      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`, `Ceci n'est pas une date`]);
+  });
+
+  it(`places invalid date strings last in the sorted order (desc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator({order: `desc`})))
+      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`, `Ceci n'est pas une date`]);
+  });
+
+  it(`sorts date strings that match a specific regex (asc)`, function() {
+    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(dateStringComparator({
+      dateRegex: /\d\d\d\d-\d\d-\d\d/,
+    }))).to.eql([`2000-08-01`, `2016-12-31`, `apr 10 2015`, `feb 4 2012`]);
+  });
+
+  it(`sorts date strings that match a specific regex (desc)`, function() {
+    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(dateStringComparator({
+      order: `desc`,
+      dateRegex: /\d\d\d\d-\d\d-\d\d/,
+    }))).to.eql([`2016-12-31`, `2000-08-01`, `apr 10 2015`, `feb 4 2012`]);
+  });
+
+  it(`can sort based on a given transformation (asc)`, function() {
+    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
+      transform: s => s.slice(0, 4),
+    }))).to.eql([`12/5/2003`, `12/6/2002`, `12/7/2001`]);
+  });
+
+  it(`can sort based on a given transformation (desc)`, function() {
+    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
+      order: `desc`,
+      transform: s => s.slice(0, 4),
+    }))).to.eql([`12/7/2001`, `12/6/2002`, `12/5/2003`]);
+  });
+});
+
+describe(`numDateAlphaComparator()`, function() {
+  it(`sorts strings (asc)`, function() {
+    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator())).to.eql([`a`, `moo`, `zzz`]);
+  });
+
+  it(`sorts strings (desc)`, function() {
+    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
+  });
+
+  it(`sorts numeric strings (asc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`].sort(numDateAlphaComparator()))
+      .to.eql([`-12,000`, `000`, `9.876`, `11`]);
+  });
+
+  it(`sorts numeric strings (desc)`, function() {
+    expect([`9.876`, `11`, `000`, `-12,000`].sort(numDateAlphaComparator({order: `desc`})))
+      .to.eql([`11`, `9.876`, `000`, `-12,000`]);
+  });
+
+  it(`sorts numbers (asc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(numDateAlphaComparator()))
+      .to.eql([-12000, 0, 9.876, 11]);
+  });
+
+  it(`sorts numbers (desc)`, function() {
+    expect([9.876, 11, 0, -12000].sort(numDateAlphaComparator({order: `desc`})))
+      .to.eql([11, 9.876, 0, -12000]);
+  });
+
+  it(`sorts date strings (asc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(numDateAlphaComparator()))
+      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`]);
+  });
+
+  it(`sorts date strings (desc)`, function() {
+    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(numDateAlphaComparator({order: `desc`})))
+      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`]);
+  });
+
+  it(`sorts date strings with a parse config (asc)`, function() {
+    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(numDateAlphaComparator({
+      parseDateConfig: {iso: true, utc: true},
+    }))).to.eql([`2000-08-01`, `2015-04-01`, `2016-12-31`]);
+  });
+
+  it(`sorts date strings with a parse config (desc)`, function() {
+    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(numDateAlphaComparator({
+      order: `desc`,
+      parseDateConfig: {iso: true, utc: true},
+    }))).to.eql([`2016-12-31`, `2015-04-01`, `2000-08-01`]);
+  });
+
+  it(`sorts date strings that match a specific regex (asc)`, function() {
+    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(numDateAlphaComparator({
+      dateRegex: /\d\d\d\d-\d\d-\d\d/,
+    }))).to.eql([`2000-08-01`, `2016-12-31`, `apr 10 2015`, `feb 4 2012`]);
+  });
+
+  it(`sorts date strings that match a specific regex (desc)`, function() {
+    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(numDateAlphaComparator({
+      order: `desc`,
+      dateRegex: /\d\d\d\d-\d\d-\d\d/,
+    }))).to.eql([`2016-12-31`, `2000-08-01`, `feb 4 2012`, `apr 10 2015`]);
+  });
+
+  it(`can sort based on a given transformation (asc)`, function() {
+    expect([`a`, `zzz`, `MOO`].sort(numDateAlphaComparator({
+      order: `desc`,
+      transform: s => s.toLowerCase(),
+    }))).to.eql([`zzz`, `MOO`, `a`]);
+  });
+
+  it(`can sort based on a given transformation (desc)`, function() {
+    expect([{a: 5}, {a: 2}, {a: 3}].sort(numDateAlphaComparator({
+      transform: o => o.a,
+    }))).to.eql([{a: 2}, {a: 3}, {a: 5}]);
+  });
+});
+
 describe(`sorted()`, function() {
   it(`defaults to normal ascending sort() behavior`, function() {
     expect(sorted([5, 2, 4, 1])).to.eql([1, 2, 4, 5]);
@@ -71,184 +298,6 @@ describe(`sorted()`, function() {
     expect(sorted([{a: 5}, {a: 2}, {a: 3}], {
       transform: o => o.a,
     })).to.eql([{a: 2}, {a: 3}, {a: 5}]);
-  });
-});
-
-describe(`baseComparator()`, function() {
-  it(`sorts strings`, function() {
-    expect([`a`, `zzz`, `moo`].sort(baseComparator())).to.eql([`a`, `moo`, `zzz`]);
-    expect([`a`, `zzz`, `moo`].sort(baseComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
-  });
-
-  it(`sorts numbers`, function() {
-    expect([9.876, 11, 0, -12000].sort(baseComparator()))
-      .to.eql([-12000, 0, 9.876, 11]);
-
-    expect([9.876, 11, 0, -12000].sort(baseComparator({order: `desc`})))
-      .to.eql([11, 9.876, 0, -12000]);
-  });
-
-  it(`can sort based on a given transformation`, function() {
-    expect([`a`, `zzz`, `MOO`].sort(baseComparator({
-      order: `desc`,
-      transform: s => s.toLowerCase(),
-    }))).to.eql([`zzz`, `MOO`, `a`]);
-
-    expect([{a: 5}, {a: 2}, {a: 3}].sort(baseComparator({
-      transform: o => o.a,
-    }))).to.eql([{a: 2}, {a: 3}, {a: 5}]);
-  });
-});
-
-describe(`numericComparator()`, function() {
-  it(`sorts numeric strings`, function() {
-    expect([`9.876`, `11`, `000`, `-12,000`].sort(numericComparator()))
-      .to.eql([`-12,000`, `000`, `9.876`, `11`]);
-
-    expect([`9.876`, `11`, `000`, `-12,000`].sort(numericComparator({order: `desc`})))
-      .to.eql([`11`, `9.876`, `000`, `-12,000`]);
-  });
-
-  it(`sorts numbers`, function() {
-    expect([9.876, 11, 0, -12000].sort(numericComparator()))
-      .to.eql([-12000, 0, 9.876, 11]);
-
-    expect([9.876, 11, 0, -12000].sort(numericComparator({order: `desc`})))
-      .to.eql([11, 9.876, 0, -12000]);
-  });
-
-  it(`places invalid numeric strings last in the sorted order for asc and desc`, function() {
-    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas une nombre`].sort(numericComparator()))
-      .to.eql([`-12,000`, `000`, `9.876`, `11`, `Ceci n'est pas une nombre`]);
-
-    expect([`9.876`, `11`, `000`, `-12,000`, `Ceci n'est pas une nombre`].sort(numericComparator({order: `desc`})))
-      .to.eql([`11`, `9.876`, `000`, `-12,000`, `Ceci n'est pas une nombre`]);
-  });
-
-  it(`can sort based on a given transformation`, function() {
-    expect([3, 5, 7].sort(numericComparator({
-      transform: n => n % 3,
-    }))).to.eql([3, 7, 5]);
-
-    expect([3, 5, 7].sort(numericComparator({
-      order: `desc`,
-      transform: n => n % 3,
-    }))).to.eql([5, 7, 3]);
-  });
-});
-
-describe(`dateStringComparator()`, function() {
-  it(`sorts date strings`, function() {
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(dateStringComparator()))
-      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`]);
-
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(dateStringComparator({order: `desc`})))
-      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`]);
-  });
-
-  it(`sorts date strings with a parse config`, function() {
-    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(dateStringComparator({
-      parseDateConfig: {iso: true, utc: true},
-    }))).to.eql([`2000-08-01`, `2015-04-01`, `2016-12-31`]);
-
-    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(dateStringComparator({
-      order: `desc`,
-      parseDateConfig: {iso: true, utc: true},
-    }))).to.eql([`2016-12-31`, `2015-04-01`, `2000-08-01`]);
-  });
-
-  it(`places invalid date strings last in the sorted order for asc and desc`, function() {
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator()))
-      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`, `Ceci n'est pas une date`]);
-
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`, `Ceci n'est pas une date`].sort(dateStringComparator({order: `desc`})))
-      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`, `Ceci n'est pas une date`]);
-  });
-
-  it(`sorts date strings that match a specific regex`, function() {
-    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(dateStringComparator({
-      dateRegex: /\d\d\d\d-\d\d-\d\d/,
-    }))).to.eql([`2000-08-01`, `2016-12-31`, `apr 10 2015`, `feb 4 2012`]);
-
-    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(dateStringComparator({
-      order: `desc`,
-      dateRegex: /\d\d\d\d-\d\d-\d\d/,
-    }))).to.eql([`2016-12-31`, `2000-08-01`, `apr 10 2015`, `feb 4 2012`]);
-  });
-
-  it(`can sort based on a given transformation`, function() {
-    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
-      transform: s => s.slice(0, 4),
-    }))).to.eql([`12/5/2003`, `12/6/2002`, `12/7/2001`]);
-
-    expect([`12/6/2002`, `12/5/2003`, `12/7/2001`].sort(dateStringComparator({
-      order: `desc`,
-      transform: s => s.slice(0, 4),
-    }))).to.eql([`12/7/2001`, `12/6/2002`, `12/5/2003`]);
-  });
-});
-
-describe(`numDateAlphaComparator()`, function() {
-  it(`sorts strings`, function() {
-    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator())).to.eql([`a`, `moo`, `zzz`]);
-    expect([`a`, `zzz`, `moo`].sort(numDateAlphaComparator({order: `desc`}))).to.eql([`zzz`, `moo`, `a`]);
-  });
-
-  it(`sorts numeric strings`, function() {
-    expect([`9.876`, `11`, `000`, `-12,000`].sort(numDateAlphaComparator()))
-      .to.eql([`-12,000`, `000`, `9.876`, `11`]);
-
-    expect([`9.876`, `11`, `000`, `-12,000`].sort(numDateAlphaComparator({order: `desc`})))
-      .to.eql([`11`, `9.876`, `000`, `-12,000`]);
-  });
-
-  it(`sorts numbers`, function() {
-    expect([9.876, 11, 0, -12000].sort(numDateAlphaComparator()))
-      .to.eql([-12000, 0, 9.876, 11]);
-
-    expect([9.876, 11, 0, -12000].sort(numDateAlphaComparator({order: `desc`})))
-      .to.eql([11, 9.876, 0, -12000]);
-  });
-
-  it(`sorts date strings`, function() {
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(numDateAlphaComparator()))
-      .to.eql([`January 8th, 2000`, `4-1-15`, `12/31/16`]);
-
-    expect([`12/31/16`, `January 8th, 2000`, `4-1-15`].sort(numDateAlphaComparator({order: `desc`})))
-      .to.eql([`12/31/16`, `4-1-15`, `January 8th, 2000`]);
-  });
-
-  it(`sorts date strings with a parse config`, function() {
-    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(numDateAlphaComparator({
-      parseDateConfig: {iso: true, utc: true},
-    }))).to.eql([`2000-08-01`, `2015-04-01`, `2016-12-31`]);
-
-    expect([`2016-12-31`, `2000-08-01`, `2015-04-01`].sort(numDateAlphaComparator({
-      order: `desc`,
-      parseDateConfig: {iso: true, utc: true},
-    }))).to.eql([`2016-12-31`, `2015-04-01`, `2000-08-01`]);
-  });
-
-  it(`sorts date strings that match a specific regex`, function() {
-    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(numDateAlphaComparator({
-      dateRegex: /\d\d\d\d-\d\d-\d\d/,
-    }))).to.eql([`2000-08-01`, `2016-12-31`, `apr 10 2015`, `feb 4 2012`]);
-
-    expect([`apr 10 2015`, `2016-12-31`, `2000-08-01`, `feb 4 2012`].sort(numDateAlphaComparator({
-      order: `desc`,
-      dateRegex: /\d\d\d\d-\d\d-\d\d/,
-    }))).to.eql([`2016-12-31`, `2000-08-01`, `feb 4 2012`, `apr 10 2015`]);
-  });
-
-  it(`can sort based on a given transformation`, function() {
-    expect([`a`, `zzz`, `MOO`].sort(numDateAlphaComparator({
-      order: `desc`,
-      transform: s => s.toLowerCase(),
-    }))).to.eql([`zzz`, `MOO`, `a`]);
-
-    expect([{a: 5}, {a: 2}, {a: 3}].sort(numDateAlphaComparator({
-      transform: o => o.a,
-    }))).to.eql([{a: 2}, {a: 3}, {a: 5}]);
   });
 });
 


### PR DESCRIPTION
Add ability to correctly sort numbers and dates with `sorted`. Fix a bug in `parseDate` where today or a future date string (i.e. "12/31/20") would be normalized to 2016.

Insights branch with example `sorted` usage: https://github.com/mixpanel-platform/insights/pull/335