### PR TITLE
always go through the _pendingAnimations flow to close or open.

### DIFF
--- a/lib/components/modal/index.js
+++ b/lib/components/modal/index.js
@@ -24,7 +24,7 @@ registerMPElement(`mp-modal`, class extends Component {
       },
       helpers: {
         backdropClicked: () => {
-          if (this.isAttributeEnabled(`closeable`) && this.state.visibility === VISIBILITY_OPEN) {
+          if (this.isAttributeEnabled(`closeable`)) {
             this.close();
           }
         },

--- a/lib/components/modal/index.js
+++ b/lib/components/modal/index.js
@@ -44,8 +44,6 @@ registerMPElement(`mp-modal`, class extends Component {
       case VISIBILITY_CLOSING:
         break;
       case VISIBILITY_OPENING:
-        this.update({visibility: VISIBILITY_CLOSED});
-        break;
       case VISIBILITY_OPEN:
         this._pendingAnimations = [`fadeModalOut`];
         if (this.config.helpers.getType() === `modal`) {
@@ -62,8 +60,6 @@ registerMPElement(`mp-modal`, class extends Component {
       case VISIBILITY_OPENING:
         break;
       case VISIBILITY_CLOSING:
-        this.update({visibility: VISIBILITY_OPEN});
-        break;
       case VISIBILITY_CLOSED:
         this._pendingAnimations = [`fadeModalIn`];
         if (this.config.helpers.getType() === `modal`) {

--- a/lib/components/modal/index.js
+++ b/lib/components/modal/index.js
@@ -24,7 +24,7 @@ registerMPElement(`mp-modal`, class extends Component {
       },
       helpers: {
         backdropClicked: () => {
-          if (this.isAttributeEnabled(`closeable`)) {
+          if (this.isAttributeEnabled(`closeable`) && this.state.visibility === VISIBILITY_OPEN) {
             this.close();
           }
         },


### PR DESCRIPTION
This is because of an insights bug -- people were double-clicking the button that opens the delete modal, and so they were clicking the backdrop before the modal was fully open, which gets it stuck in a weird state.

fixes #184 