### PR TITLE
[mixpanel-common] Fix nestedObjectDepth to work for null values

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -111,7 +111,7 @@ export function mapValues(obj, func) {
 }
 
 export function nestedObjectDepth(obj) {
-  return obj != null && typeof obj === `object` ? nestedObjectDepth(obj[Object.keys(obj)[0]]) + 1 : 0;
+  return obj !== null && typeof obj === `object` ? nestedObjectDepth(obj[Object.keys(obj)[0]]) + 1 : 0;
 }
 
 function getKeys(obj, depth, keySet) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -111,7 +111,7 @@ export function mapValues(obj, func) {
 }
 
 export function nestedObjectDepth(obj) {
-  return typeof obj === `object` ? nestedObjectDepth(obj[Object.keys(obj)[0]]) + 1 : 0;
+  return obj != null && typeof obj === `object` ? nestedObjectDepth(obj[Object.keys(obj)[0]]) + 1 : 0;
 }
 
 function getKeys(obj, depth, keySet) {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -18,6 +18,7 @@ import {
   replaceByIndex,
   insertAtIndex,
 
+  nestedObjectDepth,
   nestedObjectRolling,
 
   truncateToElement,
@@ -526,6 +527,30 @@ describe(`unique()`, function() {
         {a: 1, b: `abc`}, {a: null, b: undefined}, {a: [], b: {}},
       ]);
     });
+  });
+});
+
+const timeseriesResultObjNull = {
+  US: {
+    '2016-06-01': null,
+    '2016-06-02': null,
+    '2016-06-03': 2,
+    '2016-06-04': 8,
+    '2016-06-05': 14,
+  },
+  Canada: {
+    '2016-06-01': 6,
+    '2016-06-02': 3,
+    '2016-06-03': 3,
+    '2016-06-04': 12,
+    '2016-06-05': null,
+  },
+};
+
+describe(`nestedObjectDepth`, function() {
+  it(`supports null value leaf nodes`, function() {
+    const depth = nestedObjectDepth(timeseriesResultObjNull);
+    expect(depth).to.eql(2);
   });
 });
 


### PR DESCRIPTION
Problem: 
typeof null => 'object' 
Object.keys(null) => Uncaught TypeError: Cannot convert undefined or null to object
Ugh.

Fixes rendering time series data when certain values are null (eg. avg of non existent values etc.) 