### PR TITLE
Sorting improvements

### DIFF
--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -106,11 +106,23 @@ export function baseComparator({order=`asc`, transform=identity}={}) {
  * <<< [`12~1`, `blarg`, `12~2`].sort(baseComparator({order: `desc`, transform: dateString => dateString.replace(`~`, ` `)}));
  * >>> [`12~2`, `12~1`, `blarg`] // sorted by parseable date value
  */
-export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
+export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateCache=null, parseDateConfig={}}={}) {
+  dateRegex = dateRegex && new RegExp(dateRegex);
+
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
-    const date = (!dateRegex || new RegExp(dateRegex).test(item)) && parseDate(item, parseDateConfig);
-    return date ? date.getTime() : null;
+    let timestamp = null;
+
+    if (!dateRegex || dateRegex.test(item)) {
+      if (parseDateCache) {
+        timestamp = parseDateCache[item] || null;
+      } else {
+        const date = parseDate(item, parseDateConfig);
+        timestamp = date && date.getTime();
+      }
+    }
+
+    return timestamp;
   });
 }
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -1,3 +1,4 @@
+import { Cache } from './cache';
 import { parseDate } from './date';
 import {
   defaultOrdering,
@@ -80,40 +81,6 @@ const SORT_ORDERING = {
   desc: lexicalCompose(NULL_ORDERING, (a, b) => defaultOrdering(b, a)),
 };
 
-/** Cache object used to store sort comparison values to avoid redundant processing/parsing/etc. **/
-export class SortCache {
-  /**
-   * Create a SortCache
-   */
-  constructor() {
-    this._cache = {};
-  }
-
-  /**
-   * Add a value to the cache under key
-   * @param {string} key - the key to store the value under
-   * @param {*} value - the value to be stored
-   */
-  add(key, value) {
-    this._cache[key] = value;
-  }
-
-  /**
-   * Fetch a value from the cache under key.
-   * On cache miss, use defaultValue to return value (and store it in the cache).
-   * If no defaultValue supplied, cache miss will return null
-   * @param {string} key - the key to fetch a value for
-   * @param {*} [defaultValue] - if Function, will be called (with key as argument) to obtain value. Otherwise, will be used directly as value.
-   */
-  fetch(key, defaultValue=null) {
-    if (!this._cache.hasOwnProperty(key)) {
-      this._cache[key] = defaultValue instanceof Function ? defaultValue(key) : defaultValue;
-    }
-
-    return this._cache[key];
-  }
-}
-
 /**
  * Construct a sort comparator function that orders items by numeric value, comparing them via a <= operation.
  * null items are placed last in the sorted order.
@@ -133,7 +100,7 @@ export function baseComparator({order=`asc`, transform=identity}={}) {
  * then comparing via a <= operation. Invalid date strings are placed last in the sorted order.
  * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
- * @param {SortCache} [parseDateCache] - a SortCache instance used to store date strings <-> timestamps to avoid redundant parsing
+ * @param {Cache} [parseDateCache] - a Cache instance used to store date strings <-> timestamps to avoid redundant parsing
  * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
  * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
@@ -144,12 +111,12 @@ export function baseComparator({order=`asc`, transform=identity}={}) {
  * If you want to cache parsed date values across multiple sorts for performance, initialize your own parseDateCache externally
  * and pass in that single instance:
  *
- *   const parseDateCache = new SortCache();
+ *   const parseDateCache = new Cache();
  * ... later, within your sorting code ...
  *   array.sort(dateStringComparator({parseDateCache}));
  */
 export function dateStringComparator({order=`asc`, transform=identity, parseDateCache=null, parseDateConfig={}, dateRegex=null}={}) {
-  parseDateCache = parseDateCache || new SortCache();
+  parseDateCache = parseDateCache || new Cache();
   dateRegex = dateRegex && new RegExp(dateRegex);
 
   return mapArguments(SORT_ORDERING[order], item => {
@@ -170,7 +137,7 @@ export function dateStringComparator({order=`asc`, transform=identity, parseDate
  * then comparing via a <= operation. Invalid numeric strings are placed last in the sorted order.
  * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
- * @param {SortCache} [parseNumberCache] - a SortCache instance used to store number-like values <-> numbers to avoid redundant parsing
+ * @param {Cache} [parseNumberCache] - a Cache instance used to store number-like values <-> numbers to avoid redundant parsing
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
  * @example
  * <<< [`n:-9,000`, `n:blarg`, `n:42`].sort(baseComparator({order: `desc`, transform: numericString => numericString.split(:)[1]}));
@@ -179,12 +146,12 @@ export function dateStringComparator({order=`asc`, transform=identity, parseDate
  * If you want to cache parsed number values across multiple sorts for performance, initialize your own parseNumberCache externally
  * and pass in that single instance:
  *
- *   const parseNumberCache = new SortCache();
+ *   const parseNumberCache = new Cache();
  * ... later, within your sorting code ...
  *   array.sort(dateStringComparator({parseNumberCache}));
  */
 export function numericComparator({order=`asc`, transform=identity, parseNumberCache=null}={}) {
-  parseNumberCache = parseNumberCache || new SortCache();
+  parseNumberCache = parseNumberCache || new Cache();
 
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
@@ -200,8 +167,8 @@ export function numericComparator({order=`asc`, transform=identity, parseNumberC
  * Construct a sort comparator function that orders strings by parsed date, numeric, or alphabetic value.
  * @param {string|object} [order=`asc`] - `asc`/`desc` order string. Can also be an object like {base: `asc`, number: `desc`, date: `desc`} for finer-grained control over sub-comparators
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
- * @param {SortCache} [parseNumberCache] - a SortCache instance used to store number-like values <-> numbers to avoid redundant parsing
- * @param {SortCache} [parseDateCache] - a SortCache instance used to store date strings <-> timestamps to avoid redundant parsing
+ * @param {Cache} [parseNumberCache] - a Cache instance used to store number-like values <-> numbers to avoid redundant parsing
+ * @param {Cache} [parseDateCache] - a Cache instance used to store date strings <-> timestamps to avoid redundant parsing
  * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
  * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -80,6 +80,40 @@ const SORT_ORDERING = {
   desc: lexicalCompose(NULL_ORDERING, (a, b) => defaultOrdering(b, a)),
 };
 
+/** Cache object used to store sort comparison values to avoid redundant processing/parsing/etc. **/
+export class SortCache {
+  /**
+   * Create a SortCache
+   */
+  constructor() {
+    this._cache = {};
+  }
+
+  /**
+   * Add a value to the cache under key
+   * @param {string} key - the key to store the value under
+   * @param {*} value - the value to be stored
+   */
+  add(key, value) {
+    this._cache[key] = value;
+  }
+
+  /**
+   * Fetch a value from the cache under key.
+   * On cache miss, use defaultValue to return value (and store it in the cache).
+   * If no defaultValue supplied, cache miss will return null
+   * @param {string} key - the key to fetch a value for
+   * @param {*} [defaultValue] - if Function, will be called (with key as argument) to obtain value. Otherwise, will be used directly as value.
+   */
+  fetch(key, defaultValue=null) {
+    if (!this._cache.hasOwnProperty(key)) {
+      this._cache[key] = defaultValue instanceof Function ? defaultValue(key) : defaultValue;
+    }
+
+    return this._cache[key];
+  }
+}
+
 /**
  * Construct a sort comparator function that orders items by numeric value, comparing them via a <= operation.
  * null items are placed last in the sorted order.
@@ -99,30 +133,35 @@ export function baseComparator({order=`asc`, transform=identity}={}) {
  * then comparing via a <= operation. Invalid date strings are placed last in the sorted order.
  * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
- * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
+ * @param {SortCache} [parseDateCache] - a SortCache instance used to store date strings <-> timestamps to avoid redundant parsing
  * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
+ * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
  * @example
  * <<< [`12~1`, `blarg`, `12~2`].sort(baseComparator({order: `desc`, transform: dateString => dateString.replace(`~`, ` `)}));
  * >>> [`12~2`, `12~1`, `blarg`] // sorted by parseable date value
+ *
+ * If you want to cache parsed date values across multiple sorts for performance, initialize your own parseDateCache externally
+ * and pass in that single instance:
+ *
+ *   const parseDateCache = new SortCache();
+ * ... later, within your sorting code ...
+ *   array.sort(dateStringComparator({parseDateCache}));
  */
-export function dateStringComparator({order=`asc`, transform=identity, dateRegex=null, parseDateCache=null, parseDateConfig={}}={}) {
+export function dateStringComparator({order=`asc`, transform=identity, parseDateCache=null, parseDateConfig={}, dateRegex=null}={}) {
+  parseDateCache = parseDateCache || new SortCache();
   dateRegex = dateRegex && new RegExp(dateRegex);
 
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
-    let timestamp = null;
-
-    if (!dateRegex || dateRegex.test(item)) {
-      if (parseDateCache) {
-        timestamp = parseDateCache[item] || null;
-      } else {
+    return parseDateCache.fetch(item, item => {
+      let timestamp = null;
+      if (!dateRegex || dateRegex.test(item)) {
         const date = parseDate(item, parseDateConfig);
         timestamp = date && date.getTime();
       }
-    }
-
-    return timestamp;
+      return timestamp;
+    });
   });
 }
 
@@ -131,35 +170,63 @@ export function dateStringComparator({order=`asc`, transform=identity, dateRegex
  * then comparing via a <= operation. Invalid numeric strings are placed last in the sorted order.
  * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
+ * @param {SortCache} [parseNumberCache] - a SortCache instance used to store number-like values <-> numbers to avoid redundant parsing
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
  * @example
  * <<< [`n:-9,000`, `n:blarg`, `n:42`].sort(baseComparator({order: `desc`, transform: numericString => numericString.split(:)[1]}));
  * >>> [`n:42`, `n:-9,000`, `n:blarg`] // sorted by parseable numeric value
+ *
+ * If you want to cache parsed number values across multiple sorts for performance, initialize your own parseNumberCache externally
+ * and pass in that single instance:
+ *
+ *   const parseNumberCache = new SortCache();
+ * ... later, within your sorting code ...
+ *   array.sort(dateStringComparator({parseNumberCache}));
  */
-export function numericComparator({order=`asc`, transform=identity}={}) {
+export function numericComparator({order=`asc`, transform=identity, parseNumberCache=null}={}) {
+  parseNumberCache = parseNumberCache || new SortCache();
+
   return mapArguments(SORT_ORDERING[order], item => {
     item = transform(item);
-    const number = Number(item && item.replace ? item.replace(/,/g, ``) : item);
-    return !isNaN(number) ? number : null;
+
+    return parseNumberCache.fetch(item, item => {
+      const number = Number(item && item.replace ? item.replace(/,/g, ``) : item);
+      return !isNaN(number) ? number : null;
+    });
   });
 }
 
 /**
  * Construct a sort comparator function that orders strings by parsed date, numeric, or alphabetic value.
- * @param {string} [order=`asc`] - `asc` (default) sorts ascending; `desc` sorts descending
+ * @param {string|object} [order=`asc`] - `asc`/`desc` order string. Can also be an object like {base: `asc`, number: `desc`, date: `desc`} for finer-grained control over sub-comparators
  * @param {Function} [transform=identity] - a function that can transform each item before comparison (defaults to identity: x => x)
- * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
+ * @param {SortCache} [parseNumberCache] - a SortCache instance used to store number-like values <-> numbers to avoid redundant parsing
+ * @param {SortCache} [parseDateCache] - a SortCache instance used to store date strings <-> timestamps to avoid redundant parsing
  * @param {object} [parseDateConfig] - a config object that provides fine-grained control over how date strings are parsed (see parseDate)
+ * @param {string|RegExp} [dateRegex] - a regex that can be used to only try and parse certain strings as dates (for performance)
  * @returns {Function} - a sort comparator func that can be passed to Array.sort (for any given a and b returns one of [1, 0, -1])
  * @example
  * <<< [`12/1`, `blarg`, `-9,000`, `12/2`, `42`].sort(baseComparator({order: `desc`}));
  * >>> [`42`, `-9,000`, `12/2`, `12/1`, `blarg`]
  */
-export function numDateAlphaComparator({order=`asc`, transform=identity, dateRegex=null, parseDateCache=null, parseDateConfig={}}={}) {
+export function numDateAlphaComparator({order=`asc`, transform=identity, parseNumberCache=null, parseDateCache=null, parseDateConfig={}, dateRegex=null}={}) {
+  if (order === `asc` || order === `desc`) {
+    order = {
+      number: order,
+      date: order,
+      base: order,
+    };
+  } else {
+    order = {
+      number: order && order.number || `asc`,
+      date: order && order.date || `asc`,
+      base: order && order.base || `asc`,
+    };
+  }
   return lexicalCompose(
-    numericComparator({order: order.number || order, transform}),
-    dateStringComparator({order: order.date || order, transform, dateRegex, parseDateCache, parseDateConfig}),
-    baseComparator({order: order.base || order, transform})
+    numericComparator({order: order.number, transform, parseNumberCache}),
+    dateStringComparator({order: order.date, transform, parseDateCache, parseDateConfig, dateRegex}),
+    baseComparator({order: order.base, transform})
   );
 }
 

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -91,7 +91,10 @@ const SORT_ORDERING = {
  * <<< [1, 2, 3, 4, 5].sort(baseComparator({order: `desc`, transform: n => n % 2}));
  * >>> [2, 4, 1, 3, 5] // sorted by even numbers followed by odd numbers
  */
-export function baseComparator({order=`asc`, transform=identity}={}) {
+export function baseComparator({
+  order=`asc`,
+  transform=identity,
+}={}) {
   return mapArguments(SORT_ORDERING[order], transform);
 }
 
@@ -115,7 +118,13 @@ export function baseComparator({order=`asc`, transform=identity}={}) {
  * ... later, within your sorting code ...
  *   array.sort(dateStringComparator({parseDateCache}));
  */
-export function dateStringComparator({order=`asc`, transform=identity, parseDateCache=null, parseDateConfig={}, dateRegex=null}={}) {
+export function dateStringComparator({
+  order=`asc`,
+  transform=identity,
+  parseDateCache=null,
+  parseDateConfig={},
+  dateRegex=null,
+}={}) {
   parseDateCache = parseDateCache || new Cache();
   dateRegex = dateRegex && new RegExp(dateRegex);
 
@@ -150,7 +159,11 @@ export function dateStringComparator({order=`asc`, transform=identity, parseDate
  * ... later, within your sorting code ...
  *   array.sort(dateStringComparator({parseNumberCache}));
  */
-export function numericComparator({order=`asc`, transform=identity, parseNumberCache=null}={}) {
+export function numericComparator({
+  order=`asc`,
+  transform=identity,
+  parseNumberCache=null,
+}={}) {
   parseNumberCache = parseNumberCache || new Cache();
 
   return mapArguments(SORT_ORDERING[order], item => {
@@ -176,7 +189,14 @@ export function numericComparator({order=`asc`, transform=identity, parseNumberC
  * <<< [`12/1`, `blarg`, `-9,000`, `12/2`, `42`].sort(baseComparator({order: `desc`}));
  * >>> [`42`, `-9,000`, `12/2`, `12/1`, `blarg`]
  */
-export function numDateAlphaComparator({order=`asc`, transform=identity, parseNumberCache=null, parseDateCache=null, parseDateConfig={}, dateRegex=null}={}) {
+export function numDateAlphaComparator({
+  order=`asc`,
+  transform=identity,
+  parseNumberCache=null,
+  parseDateCache=null,
+  parseDateConfig={},
+  dateRegex=null,
+}={}) {
   if (order === `asc` || order === `desc`) {
     order = {
       number: order,

--- a/lib/util/array.js
+++ b/lib/util/array.js
@@ -143,11 +143,11 @@ export function numericComparator({order=`asc`, transform=identity}={}) {
  * <<< [`12/1`, `blarg`, `-9,000`, `12/2`, `42`].sort(baseComparator({order: `desc`}));
  * >>> [`42`, `-9,000`, `12/2`, `12/1`, `blarg`]
  */
-export function numDateAlphaComparator({order=`asc`, transform=identity, dateRegex=null, parseDateConfig={}}={}) {
+export function numDateAlphaComparator({order=`asc`, transform=identity, dateRegex=null, parseDateCache=null, parseDateConfig={}}={}) {
   return lexicalCompose(
-    numericComparator({order, transform}),
-    dateStringComparator({order, transform, dateRegex, parseDateConfig}),
-    baseComparator({order, transform})
+    numericComparator({order: order.number || order, transform}),
+    dateStringComparator({order: order.date || order, transform, dateRegex, parseDateCache, parseDateConfig}),
+    baseComparator({order: order.base || order, transform})
   );
 }
 

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -1,0 +1,32 @@
+/** Cache object used to store key/value pairs in memory **/
+export class Cache {
+  /**
+   * Create a Cache
+   */
+  constructor() {
+    this._cache = new Map();
+  }
+
+  /**
+   * Add a value to the cache under key
+   * @param {string} key - the key to store the value under
+   * @param {*} value - the value to be stored
+   */
+  add(key, value) {
+    this._cache.set(key, value);
+  }
+
+  /**
+   * Fetch a value from the cache under key.
+   * On cache miss, use defaultValue to return value (and store it in the cache).
+   * If no defaultValue supplied, cache miss will return null
+   * @param {string} key - the key to fetch a value for
+   * @param {*} [defaultValue] - if Function, will be called (with key as argument) to obtain value. Otherwise, will be used directly as value.
+   */
+  fetch(key, defaultValue=null) {
+    if (!this._cache.has(key)) {
+      this.add(key, defaultValue instanceof Function ? defaultValue(key) : defaultValue);
+    }
+    return this._cache.get(key);
+  }
+}

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -8,7 +8,7 @@ export class Cache {
   }
 
   /**
-   * Add a value to the cache under key
+   * Add a value to the cache under key.
    * @param {string} key - the key to store the value under
    * @param {*} value - the value to be stored
    */
@@ -19,14 +19,30 @@ export class Cache {
   /**
    * Fetch a value from the cache under key.
    * On cache miss, use defaultValue to return value (and store it in the cache).
-   * If no defaultValue supplied, cache miss will return null
+   * If no defaultValue supplied, cache miss will return undefined.
    * @param {string} key - the key to fetch a value for
    * @param {*} [defaultValue] - if Function, will be called (with key as argument) to obtain value. Otherwise, will be used directly as value.
    */
-  fetch(key, defaultValue=null) {
-    if (!this._cache.has(key)) {
+  fetch(key, defaultValue) {
+    if (!this.has(key) && defaultValue !== undefined) {
       this.add(key, defaultValue instanceof Function ? defaultValue(key) : defaultValue);
     }
     return this._cache.get(key);
+  }
+
+  /**
+   * Return true if the given key exists in the cache; false otherwise.
+   * @param {string} key - the key to fetch a value for
+   */
+  has(key) {
+    return this._cache.has(key);
+  }
+
+  /**
+   * Remove a value from the cache under key. Return true if the given key existed; false otherwise.
+   * @param {string} key - the key to fetch a value for
+   */
+  remove(key) {
+    return this._cache.delete(key);
   }
 }

--- a/test/util/cache.js
+++ b/test/util/cache.js
@@ -1,0 +1,138 @@
+/* global describe, it */
+import expect from 'expect.js';
+
+import {
+  Cache
+} from '../../lib/util/cache';
+
+const INPUTS = [
+  `a`,
+  `abc`,
+  ``,
+  `計算機科學只有兩個難點：緩存無效和命名的東西`,
+  123,
+  0,
+  -1,
+  1/3,
+  3.14159265359,
+  Infinity,
+  -Infinity,
+  null,
+  undefined,
+  [],
+  [1, 2, 3],
+  [[], [], []],
+  [[1, 2], [1, 2]],
+  {},
+  {a: 1, b: 2},
+  {a: {}, b: {}},
+  {a: {a: 1}, b: {b: 2}},
+  function () {},
+  () => {},
+  new Date(),
+  new Cache(),
+
+  // ensure there are no problems with methods/properties that
+  // may exist on the underlying map object prototype
+  `get`,
+  `set`,
+  `prototype`,
+  `length`,
+  `size`,
+  `call`,
+  `apply`,
+];
+
+describe(`Cache`, function() {
+  it(`can add any type of key/value`, function() {
+    const cache = new Cache();
+
+    for (const key of INPUTS) {
+      for (const value of INPUTS) {
+        cache.add(key, value);
+        expect(cache.fetch(key)).to.eql(value);
+
+        // ensure adding the same key multiple times has no effect
+        cache.add(key, value);
+        expect(cache.fetch(key)).to.eql(value);
+      }
+    }
+  });
+
+  it(`can fetch any type of key/value`, function() {
+    const cache = new Cache();
+
+    for (const key of INPUTS) {
+      for (const value of INPUTS) {
+        cache.remove(key);
+        expect(cache.fetch(key)).to.eql(undefined);
+        cache.add(key, value);
+        expect(cache.fetch(key)).to.eql(value);
+      }
+    }
+  });
+
+  it(`can fetch any type of key/value with a defaultValue of any non-function type supplied`, function() {
+    const cache = new Cache();
+
+    for (const key of INPUTS) {
+      for (const defaultValue of INPUTS) {
+        if (!defaultValue instanceof Function) {
+          cache.remove(key)
+          expect(cache.fetch(key)).to.eql(undefined);
+          expect(cache.fetch(key, defaultValue)).to.eql(defaultValue);
+          expect(cache.fetch(key)).to.eql(defaultValue);
+        }
+      }
+    }
+  });
+
+  it(`can fetch any type of key/value with a defaultValue function supplied`, function() {
+    const cache = new Cache();
+    let defaultValueFunc, defaultValueFuncCallCount;
+
+    for (const key of INPUTS) {
+      defaultValueFuncCallCount = 0;
+      defaultValueFunc = key => {
+        defaultValueFuncCallCount++;
+        return [key, key];
+      };
+
+      cache.remove(key)
+      expect(cache.fetch(key)).to.eql(undefined);
+      expect(defaultValueFuncCallCount).to.eql(0);
+
+      expect(cache.fetch(key, defaultValueFunc)).to.eql([key, key]);
+      expect(defaultValueFuncCallCount).to.eql(1);
+
+      expect(cache.fetch(key)).to.eql([key, key]);
+      expect(defaultValueFuncCallCount).to.eql(1);
+    }
+  });
+
+  it(`can check existence any type of key/value`, function() {
+    const cache = new Cache();
+
+    for (const key of INPUTS) {
+      for (const value of INPUTS) {
+        cache.remove(key);
+        expect(cache.has(key)).to.eql(false);
+        cache.add(key, value);
+        expect(cache.has(key)).to.eql(true);
+      }
+    }
+  });
+
+  it(`can remove any type of key/value`, function() {
+    const cache = new Cache();
+
+    for (const key of INPUTS) {
+      for (const value of INPUTS) {
+        expect(cache.remove(key)).to.eql(false);
+        cache.add(key, value);
+        expect(cache.remove(key)).to.eql(true);
+        expect(cache.remove(key)).to.eql(false);
+      }
+    }
+  });
+});

--- a/test/util/date.js
+++ b/test/util/date.js
@@ -1,5 +1,6 @@
 /* global describe, it */
 import expect from 'expect.js';
+import moment from 'moment';
 
 import {
   parseDate,
@@ -11,11 +12,10 @@ import {
 } from '../../lib/util/date';
 
 const NOW = new Date();
-const CURRENT_DATE_ISO = [
-  NOW.getFullYear(),
-  (`0` + (NOW.getMonth() + 1)).slice(-2),
-  (`0` + NOW.getDate()).slice(-2),
-].map(String).join(`-`);
+const DATE_FORMAT = `YYYY-MM-DD`;
+const DATE_TIME_FORMAT = `YYYY-MM-DDTHH:mm:ss`;
+const CURRENT_DATE_ISO = moment(NOW).format(DATE_FORMAT);
+const CURRENT_DATE_TIME_ISO = moment(NOW).format(DATE_TIME_FORMAT);
 
 const NON_DATE_INPUTS = [
   ``,
@@ -366,8 +366,8 @@ describe(`normalizeDateStrings`, function() {
   it('allows utc offset to define the current moment', function() {
     const oneDayFromNow = new Date();
     oneDayFromNow.setDate(oneDayFromNow.getDate() + 1);
-    const inputDates = [NOW.toISOString(), oneDayFromNow.toISOString()];
-    const outputDates = [CURRENT_DATE_ISO, oneDayFromNow.toISOString().split('T')[0]];
+    const inputDates = [CURRENT_DATE_TIME_ISO, moment(oneDayFromNow).format(DATE_TIME_FORMAT)];
+    const outputDates = [CURRENT_DATE_ISO, moment(oneDayFromNow).format(DATE_FORMAT)];
     const utcOffset = 24 * 60; // include one day of offset hours
     expect(normalizeDateStrings(inputDates, {utcOffset})).to.eql(outputDates);
   });


### PR DESCRIPTION
Adds
- ability to control individual orderings of numeric, date, base comparators within `numDateAlphaComparator`
- ability to pass a cache/map of date strings to timestamps to avoid parsing dates unnecessarily (optimization)

Tests in progress, will add docs once we're settled on the api/behavior