### PR TITLE
Fix tooltip on add-to-dash

### DIFF
--- a/lib/widgets/add-to-dash/index.styl
+++ b/lib/widgets/add-to-dash/index.styl
@@ -13,6 +13,8 @@
     box-sizing border-box
 
   .container
+    position relative
+
     .icon
       position relative
 


### PR DESCRIPTION
As is, the tooltip that shows when a report type is not supported is broken.