### PR TITLE
Inline css from @import

### DIFF
--- a/build.js
+++ b/build.js
@@ -77,6 +77,7 @@ function compileStylus(filename) {
     .include(path.resolve('./node_modules'))
     .define('url', stylus.url())
     .use(autoprefixer())
+    .set('include css', true)
     .render();
 }
 


### PR DESCRIPTION
By default "@import <path>.css" in a stylus file will be interpreted as a CSS import, and will not inline the contents of the file. Enabling this `include css` setting causes the contents of the imported css file to be inlined.